### PR TITLE
47 blog   implementacao teste de delete no service e controller

### DIFF
--- a/src/modules/blog/blog.controller.spec.ts
+++ b/src/modules/blog/blog.controller.spec.ts
@@ -9,6 +9,7 @@ describe('BlogController', () => {
     criarPost: jest.fn(),
     getAll: jest.fn(),
     getById: jest.fn(),
+    deleteById: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -81,5 +82,12 @@ describe('BlogController', () => {
 
     await expect(controller.getById(1)).resolves.toEqual(mockPost);
     expect(mockBlogService.getById).toHaveBeenCalledWith(1);
+  });
+
+  it('deve deletar um post do blog com sucesso!', async () => {
+    mockBlogService.deleteById.mockResolvedValue(undefined);
+
+    await expect(controller.deleteById(1)).resolves.toBeUndefined();
+    expect(mockBlogService.deleteById).toHaveBeenCalledWith(1);
   });
 });

--- a/src/modules/blog/blog.service.spec.ts
+++ b/src/modules/blog/blog.service.spec.ts
@@ -90,4 +90,27 @@ describe('BlogService', () => {
     await expect(service.getById(999)).rejects.toThrow('Post não encontrado');
     expect(mockBlogModel.findByPk).toHaveBeenCalledWith(999);
   });
+
+  it('deve deletar um post do blog com sucesso!', async () => {
+    const mockPost = {
+      destroy: jest.fn(),
+    };
+
+    mockBlogModel.findByPk.mockResolvedValue(mockPost);
+
+    await expect(service.deleteById(1)).resolves.toBeUndefined();
+
+    expect(mockBlogModel.findByPk).toHaveBeenCalledWith(1);
+    expect(mockPost.destroy).toHaveBeenCalled();
+  });
+
+  it('deve lançar erro ao deletar post inexistente', async () => {
+    mockBlogModel.findByPk.mockResolvedValue(null);
+
+    await expect(service.deleteById(999)).rejects.toThrow(
+      'Post não encontrado',
+    );
+
+    expect(mockBlogModel.findByPk).toHaveBeenCalledWith(999);
+  });
 });


### PR DESCRIPTION
Implementação dos testes do método DELETE para o módulo Blog.

Alterações realizadas:
- Adicionado teste do método deleteById no BlogService
- Adicionado teste do método deleteById no BlogController
- Mock do delete no serviço para validar chamada correta

closes #47