### PR TITLE
feat(blog): adiciona endpoint de update e testes do controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -713,9 +713,9 @@
       "license": "MIT"
     },
     "node_modules/@borewit/text-codec": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2347,12 +2347,12 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
-      "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
+      "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
       "dependencies": {
-        "file-type": "21.3.0",
+        "file-type": "21.3.2",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -5823,9 +5823,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",

--- a/src/modules/blog/blog.controller.spec.ts
+++ b/src/modules/blog/blog.controller.spec.ts
@@ -10,6 +10,7 @@ describe('BlogController', () => {
     getAll: jest.fn(),
     getById: jest.fn(),
     deleteById: jest.fn(),
+    updateBlog: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -89,5 +90,26 @@ describe('BlogController', () => {
 
     await expect(controller.deleteById(1)).resolves.toBeUndefined();
     expect(mockBlogService.deleteById).toHaveBeenCalledWith(1);
+  });
+
+  it('deve atualizar post de blog com sucesso!', async () => {
+    const postData = {
+      titulo: 'Título do Post',
+      conteudo: 'Conteúdo do post',
+      dataPublicacao: new Date(),
+      urlImagem: 'http://example.com/post',
+    };
+
+    const mockPostAtualizado = {
+      id: 1,
+      ...postData,
+    };
+
+    mockBlogService.updateBlog.mockResolvedValue(mockPostAtualizado);
+
+    await expect(controller.updateBlog(1, postData)).resolves.toEqual(
+      mockPostAtualizado,
+    );
+    expect(mockBlogService.updateBlog).toHaveBeenCalledWith(1, postData);
   });
 });

--- a/src/modules/blog/blog.controller.ts
+++ b/src/modules/blog/blog.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Put,
   Delete,
   HttpCode,
 } from '@nestjs/common';
@@ -41,5 +42,14 @@ export class BlogController {
   deleteById(@Param('id', ParseIntPipe) id: number): Promise<void> {
     this.logger.log(`Iniciando remoção de post do blog por Id...`);
     return this.blogService.deleteById(id);
+  }
+
+  @Put(':id')
+  updateBlog(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() blogDto: BlogCreateDto,
+  ): Promise<Blog> {
+    this.logger.log(`Iniciando atualização de post no blog...`);
+    return this.blogService.updateBlog(id, blogDto);
   }
 }


### PR DESCRIPTION
### **Descrição**

Nesta PR foram implementados o endpoint de atualização de posts no módulo blog e seu respectivo teste.

### **O que foi feito**

- Adicionado o endpoint PUT /blog/:id para atualizar um post existente pelo ID.

- No controller, foi incluída a validação do parâmetro id utilizando ParseIntPipe.

- Teste adicionado no blog.controller.spec.ts:

### **Validações**

Lint verificado sem erros.
Testes executados com sucesso.
closes #28