### PR TITLE
feat:Criação da função createServico

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@nestjs/common": "^11.0.1",
+        "@nestjs/common": "^11.1.16",
         "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.0.1",
         "@nestjs/mapped-types": "*",
@@ -227,7 +227,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2125,7 +2124,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2295,8 +2293,6 @@
       "version": "11.1.16",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
       "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -2344,7 +2340,6 @@
       "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2405,7 +2400,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.16.tgz",
       "integrity": "sha512-IOegr5+ZfUiMKgk+garsSU4MOkPRhm46e6w8Bp1GcO4vCdl9Piz6FlWAzKVfa/U3Hn/DdzSVJOW3TWcQQFdBDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2427,7 +2421,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.16.tgz",
       "integrity": "sha512-3fYQTi8F2hb7HDkes/ArGhY8lkjB/Df29F5CN4cjbk4cmfpRVy89p6N1BC7PjVOHMAzdwqeX8FabqspdSAnywA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -2620,7 +2613,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.16.tgz",
       "integrity": "sha512-kfLhCFsq6139JVFCQpbFB6LOEjZzdpE7JzXsZtRbVjqmsgTKVSIh8gKRgzpcq27rbLNqHhhZavboOltOfSxZow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -2901,7 +2893,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3020,7 +3011,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3095,8 +3085,7 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -3160,7 +3149,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3868,7 +3856,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3918,7 +3905,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4347,7 +4333,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4546,7 +4531,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4594,15 +4578,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5360,7 +5342,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5421,7 +5402,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6709,7 +6689,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8548,7 +8527,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8718,8 +8696,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -8822,7 +8799,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8921,7 +8897,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -8987,7 +8962,6 @@
       "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-2.1.6.tgz",
       "integrity": "sha512-Vc2N++3en346RsbGjL3h7tgAl2Y7V+2liYTAOZ8XL0KTw3ahFHsyAUzOwct51n+g70I1TOUDgs06Oh6+XGcFkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "7.2.0"
       },
@@ -9629,7 +9603,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9963,7 +9936,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10111,7 +10083,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10466,6 +10437,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -10484,6 +10456,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -10497,6 +10470,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -10511,6 +10485,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -10520,7 +10495,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -10528,6 +10504,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10538,6 +10515,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10551,6 +10529,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5848,11 +5848,10 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
-      "dev": true,
-      "license": "ISC"
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "dev": true
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -713,9 +713,9 @@
       "license": "MIT"
     },
     "node_modules/@borewit/text-codec": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
-      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2290,11 +2290,12 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.16",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
-      "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
+      "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
+      "license": "MIT",
       "dependencies": {
-        "file-type": "21.3.0",
+        "file-type": "21.3.2",
         "iterare": "1.2.1",
         "load-esm": "1.0.3",
         "tslib": "2.8.1",
@@ -5765,9 +5766,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
-      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
@@ -5848,10 +5849,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -9167,9 +9169,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -9430,9 +9432,9 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
-      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs/common": "^11.0.1",
+    "@nestjs/common": "^11.1.16",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",
     "@nestjs/mapped-types": "*",

--- a/src/models/servico.model.ts
+++ b/src/models/servico.model.ts
@@ -25,6 +25,6 @@ export class Servico extends Model {
   })
   declare prazoEstimadoDias: number | null;
 
-  @Column({ allowNull: true, defaultValue: true })
+  @Column({ type: DataType.BOOLEAN, allowNull: true, defaultValue: true })
   declare ativo: boolean | null;
 }

--- a/src/modules/servicos/servicos.controller.spec.ts
+++ b/src/modules/servicos/servicos.controller.spec.ts
@@ -1,20 +1,68 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServicosController } from './servicos.controller';
 import { ServicosService } from './servicos.service';
+import { NotFoundException } from '@nestjs/common';
 
 describe('ServicosController', () => {
   let controller: ServicosController;
 
+  const mockServicosService = {
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ServicosController],
-      providers: [ServicosService],
+      providers: [
+        {
+          provide: ServicosService,
+          useValue: mockServicosService,
+        },
+      ],
     }).compile();
 
     controller = module.get<ServicosController>(ServicosController);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('deve retornar lista de serviços', async () => {
+      const mockList = [
+        { id: 1, nome: 'Troca de óleo', descricao: 'Serviço de troca de óleo' },
+        { id: 2, nome: 'Alinhamento', descricao: 'Serviço de alinhamento' },
+      ];
+      mockServicosService.findAll.mockResolvedValue(mockList);
+
+      const result = await controller.findAll();
+
+      expect(result).toEqual(mockList);
+      expect(mockServicosService.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('deve retornar o serviço quando encontrado', async () => {
+      const mockServico = { id: 1, nome: 'Troca de óleo', descricao: 'Serviço de troca de óleo' };
+      mockServicosService.findOne.mockResolvedValue(mockServico);
+
+      const result = await controller.findOne(1);
+
+      expect(result).toEqual(mockServico);
+      expect(mockServicosService.findOne).toHaveBeenCalledWith(1);
+    });
+
+    it('deve propagar NotFoundException quando serviço não encontrado', async () => {
+      mockServicosService.findOne.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.findOne(99)).rejects.toThrow(NotFoundException);
+    });
   });
 });

--- a/src/modules/servicos/servicos.controller.spec.ts
+++ b/src/modules/servicos/servicos.controller.spec.ts
@@ -41,9 +41,7 @@ describe('ServicosController', () => {
       ];
       mockServicosService.findAll.mockResolvedValue(mockList);
 
-      const result = await controller.findAll();
-
-      expect(result).toEqual(mockList);
+      await expect(controller.findAll()).resolves.toEqual(mockList);
       expect(mockServicosService.findAll).toHaveBeenCalled();
     });
   });
@@ -57,9 +55,7 @@ describe('ServicosController', () => {
       };
       mockServicosService.findOne.mockResolvedValue(mockServico);
 
-      const result = await controller.findOne(1);
-
-      expect(result).toEqual(mockServico);
+      await expect(controller.findOne(1)).resolves.toEqual(mockServico);
       expect(mockServicosService.findOne).toHaveBeenCalledWith(1);
     });
 

--- a/src/modules/servicos/servicos.controller.spec.ts
+++ b/src/modules/servicos/servicos.controller.spec.ts
@@ -50,7 +50,11 @@ describe('ServicosController', () => {
 
   describe('findOne', () => {
     it('deve retornar o serviço quando encontrado', async () => {
-      const mockServico = { id: 1, nome: 'Troca de óleo', descricao: 'Serviço de troca de óleo' };
+      const mockServico = {
+        id: 1,
+        nome: 'Troca de óleo',
+        descricao: 'Serviço de troca de óleo',
+      };
       mockServicosService.findOne.mockResolvedValue(mockServico);
 
       const result = await controller.findOne(1);

--- a/src/modules/servicos/servicos.controller.spec.ts
+++ b/src/modules/servicos/servicos.controller.spec.ts
@@ -17,4 +17,18 @@ describe('ServicosController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
+
+  it('deve retornar mensagem de sucesso', () => {
+    const resposta = controller.criar({
+      nome: 'Troca de óleo',
+      descricao: 'Troca completa do óleo do motor',
+      valor_base: 120.5,
+      prazo_estimado_dias: 2,
+      ativo: true,
+    });
+
+    expect(resposta).toEqual({
+      message: 'Serviço criado com sucesso',
+    });
+  });
 });

--- a/src/modules/servicos/servicos.controller.spec.ts
+++ b/src/modules/servicos/servicos.controller.spec.ts
@@ -9,6 +9,8 @@ describe('ServicosController', () => {
   const mockServicosService = {
     findAll: jest.fn(),
     findOne: jest.fn(),
+    updateServico: jest.fn(),
+    deleteServico: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -63,6 +65,48 @@ describe('ServicosController', () => {
       mockServicosService.findOne.mockRejectedValue(new NotFoundException());
 
       await expect(controller.findOne(99)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateServico', () => {
+    it('deve retornar o serviço atualizado', async () => {
+      const id = 1;
+      const dto = { nome: 'Novo Nome' };
+      const mockResult = { id, ...dto };
+
+      mockServicosService.updateServico = jest
+        .fn()
+        .mockResolvedValue(mockResult);
+
+      const result = await controller.updateServico(id, dto);
+
+      expect(mockServicosService.updateServico).toHaveBeenCalledWith(id, dto);
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('deleteServico', () => {
+    it('deve deletar um serviço com sucesso', async () => {
+      const id = 1;
+
+      // Configuramos o mock para apenas resolver (já que o delete retorna void/undefined)
+      mockServicosService.deleteServico = jest
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await controller.deleteServico(id);
+
+      expect(mockServicosService.deleteServico).toHaveBeenCalledWith(id);
+    });
+
+    it('deve propagar NotFoundException quando serviço não encontrado para deletar', async () => {
+      mockServicosService.deleteServico = jest
+        .fn()
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(controller.deleteServico(99)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/modules/servicos/servicos.controller.spec.ts
+++ b/src/modules/servicos/servicos.controller.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServicosController } from './servicos.controller';
 import { ServicosService } from './servicos.service';
-import { NotFoundException } from '@nestjs/common';
 
 describe('ServicosController', () => {
   let controller: ServicosController;
@@ -11,6 +10,7 @@ describe('ServicosController', () => {
     findOne: jest.fn(),
     updateServico: jest.fn(),
     deleteServico: jest.fn(),
+    criarServico: jest.fn(),
   };
 
   beforeEach(async () => {

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { ServicosService } from './servicos.service';
+import { Servico } from 'src/models/servico.model';
 
 @Controller('servicos')
 export class ServicosController {

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -1,7 +1,17 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { ServicosService } from './servicos.service';
 
 @Controller('servicos')
 export class ServicosController {
   constructor(private readonly servicosService: ServicosService) {}
+
+  @Get()
+  async findAll() {
+    return this.servicosService.findAll();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.servicosService.findOne(id);
+  }
 }

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -6,12 +6,12 @@ export class ServicosController {
   constructor(private readonly servicosService: ServicosService) {}
 
   @Get()
-  async findAll() {
+  findAll(): Promise<Servico[]> {
     return this.servicosService.findAll();
   }
 
   @Get(':id')
-  async findOne(@Param('id', ParseIntPipe) id: number) {
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<Servico> {
     return this.servicosService.findOne(id);
   }
 }

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
 import { ServicosService } from './servicos.service';
-import { Servico } from 'src/models/servico.model';
 
 @Controller('servicos')
 export class ServicosController {
@@ -18,6 +17,7 @@ export class ServicosController {
       ativo: boolean;
     },
   ) {
+    // Chama o service passando os campos individualmente ou o objeto body completo
     this.servicosService.criarServico(
       body.nome,
       body.descricao,

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -1,7 +1,20 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
 import { ServicosService } from './servicos.service';
 
 @Controller('servicos')
 export class ServicosController {
   constructor(private readonly servicosService: ServicosService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async criar(@Body() body: { nome: string; descricao?: string }) {
+    await this.servicosService.criarServico(
+      body.nome,
+      body.descricao,
+    );
+
+    return {
+      message: 'Serviço criado com sucesso',
+    };
+  }
 }

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Body,
+  Patch,
+  Delete,
+} from '@nestjs/common';
 import { ServicosService } from './servicos.service';
 import { Servico } from 'src/models/servico.model';
 
@@ -14,5 +22,18 @@ export class ServicosController {
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number): Promise<Servico> {
     return this.servicosService.findOne(id);
+  }
+
+  @Patch(':id')
+  updateServico(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dados: Partial<Servico>,
+  ): Promise<Servico> {
+    return this.servicosService.updateServico(id, dados);
+  }
+
+  @Delete(':id')
+  deleteServico(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.servicosService.deleteServico(id);
   }
 }

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -1,21 +1,13 @@
-import {
-  Controller,
-  Post,
-  Body,
-  HttpCode,
-  HttpStatus,
-} from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
 import { ServicosService } from './servicos.service';
 
 @Controller('servicos')
 export class ServicosController {
-  constructor(
-    private readonly servicosService: ServicosService,
-  ) {}
+  constructor(private readonly servicosService: ServicosService) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  async criar(
+  criar(
     @Body()
     body: {
       nome: string;
@@ -25,7 +17,7 @@ export class ServicosController {
       ativo: boolean;
     },
   ) {
-    await this.servicosService.criarServico(
+    this.servicosService.criarServico(
       body.nome,
       body.descricao,
       body.valor_base,

--- a/src/modules/servicos/servicos.controller.ts
+++ b/src/modules/servicos/servicos.controller.ts
@@ -1,16 +1,36 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { ServicosService } from './servicos.service';
 
 @Controller('servicos')
 export class ServicosController {
-  constructor(private readonly servicosService: ServicosService) {}
+  constructor(
+    private readonly servicosService: ServicosService,
+  ) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  async criar(@Body() body: { nome: string; descricao?: string }) {
+  async criar(
+    @Body()
+    body: {
+      nome: string;
+      descricao: string;
+      valor_base: number;
+      prazo_estimado_dias: number;
+      ativo: boolean;
+    },
+  ) {
     await this.servicosService.criarServico(
       body.nome,
       body.descricao,
+      body.valor_base,
+      body.prazo_estimado_dias,
+      body.ativo,
     );
 
     return {

--- a/src/modules/servicos/servicos.module.ts
+++ b/src/modules/servicos/servicos.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
-import { ServicosService } from './servicos.service';
+import { SequelizeModule } from '@nestjs/sequelize';
 import { ServicosController } from './servicos.controller';
+import { ServicosService } from './servicos.service';
+import { Servico } from 'src/models/servico.model';
 
 @Module({
+  imports: [SequelizeModule.forFeature([Servico])],
   controllers: [ServicosController],
   providers: [ServicosService],
 })

--- a/src/modules/servicos/servicos.service.spec.ts
+++ b/src/modules/servicos/servicos.service.spec.ts
@@ -1,18 +1,70 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServicosService } from './servicos.service';
+import { getModelToken } from '@nestjs/sequelize';
+import { Servico } from 'src/models/servico.model';
+import { NotFoundException } from '@nestjs/common';
 
 describe('ServicosService', () => {
   let service: ServicosService;
 
+  const mockServicoModel = {
+    findAll: jest.fn(),
+    findByPk: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ServicosService],
+      providers: [
+        ServicosService,
+        {
+          provide: getModelToken(Servico),
+          useValue: mockServicoModel,
+        },
+      ],
     }).compile();
 
     service = module.get<ServicosService>(ServicosService);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('deve retornar a lista de serviços', async () => {
+      const mockList = [
+        { id: 1, nome: 'Troca de óleo', descricao: 'Serviço de troca de óleo' },
+        { id: 2, nome: 'Alinhamento', descricao: 'Serviço de alinhamento' },
+      ];
+      mockServicoModel.findAll.mockResolvedValue(mockList);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual(mockList);
+      expect(mockServicoModel.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOne', () => {
+    it('deve retornar o serviço quando encontrado', async () => {
+      const mockServico = { id: 1, nome: 'Troca de óleo', descricao: 'Serviço de troca de óleo' };
+      mockServicoModel.findByPk.mockResolvedValue(mockServico);
+
+      const result = await service.findOne(1);
+
+      expect(result).toEqual(mockServico);
+      expect(mockServicoModel.findByPk).toHaveBeenCalledWith(1);
+    });
+
+    it('deve lançar NotFoundException quando serviço não encontrado', async () => {
+      mockServicoModel.findByPk.mockResolvedValue(null);
+
+      await expect(service.findOne(99)).rejects.toThrow(NotFoundException);
+      expect(mockServicoModel.findByPk).toHaveBeenCalledWith(99);
+    });
   });
 });

--- a/src/modules/servicos/servicos.service.spec.ts
+++ b/src/modules/servicos/servicos.service.spec.ts
@@ -51,7 +51,11 @@ describe('ServicosService', () => {
 
   describe('findOne', () => {
     it('deve retornar o serviço quando encontrado', async () => {
-      const mockServico = { id: 1, nome: 'Troca de óleo', descricao: 'Serviço de troca de óleo' };
+      const mockServico = {
+        id: 1,
+        nome: 'Troca de óleo',
+        descricao: 'Serviço de troca de óleo',
+      };
       mockServicoModel.findByPk.mockResolvedValue(mockServico);
 
       const result = await service.findOne(1);

--- a/src/modules/servicos/servicos.service.spec.ts
+++ b/src/modules/servicos/servicos.service.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServicosService } from './servicos.service';
 import { getModelToken } from '@nestjs/sequelize';
@@ -69,6 +71,51 @@ describe('ServicosService', () => {
 
       await expect(service.findOne(99)).rejects.toThrow(NotFoundException);
       expect(mockServicoModel.findByPk).toHaveBeenCalledWith(99);
+    });
+  });
+
+  describe('updateServico', () => {
+    it('deve atualizar um serviço com sucesso', async () => {
+      const mockServico = {
+        id: 1,
+        nome: 'Original',
+        update: jest.fn().mockResolvedValue(undefined),
+        reload: jest.fn().mockResolvedValue({ id: 1, nome: 'Atualizado' }),
+      };
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockServico as any);
+
+      const dadosParaAtualizar = { nome: 'Atualizado' };
+      const resultado = await service.updateServico(1, dadosParaAtualizar);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(mockServico.update).toHaveBeenCalled();
+      expect(mockServico.reload).toHaveBeenCalled();
+      expect(resultado.nome).toBe('Atualizado');
+    });
+  });
+
+  describe('deleteServico', () => {
+    it('deve deletar um serviço com sucesso', async () => {
+      const mockServico = {
+        id: 1,
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockServico as any);
+
+      await service.deleteServico(1);
+
+      expect(service.findOne).toHaveBeenCalledWith(1);
+      expect(mockServico.destroy).toHaveBeenCalled();
+    });
+
+    it('deve lançar erro se tentar deletar um serviço inexistente', async () => {
+      jest.spyOn(service, 'findOne').mockRejectedValue(new NotFoundException());
+
+      await expect(service.deleteServico(99)).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/src/modules/servicos/servicos.service.spec.ts
+++ b/src/modules/servicos/servicos.service.spec.ts
@@ -15,4 +15,18 @@ describe('ServicosService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
+
+  it('deve criar um novo serviço', () => {
+    const resultado = service.criarServico(
+      'Troca de óleo',
+      'Troca completa do óleo do motor',
+      120.5,
+      2,
+      true,
+    );
+
+    expect(resultado).toBeDefined();
+    expect(resultado.nome).toBe('Troca de óleo');
+    expect(resultado.valor_base).toBe(120.5);
+  });
 });

--- a/src/modules/servicos/servicos.service.spec.ts
+++ b/src/modules/servicos/servicos.service.spec.ts
@@ -1,42 +1,22 @@
-/* eslint-disable @typescript-eslint/unbound-method */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServicosService } from './servicos.service';
-import { getModelToken } from '@nestjs/sequelize';
-import { Servico } from 'src/models/servico.model';
-import { NotFoundException } from '@nestjs/common';
 
 describe('ServicosService', () => {
   let service: ServicosService;
 
-  const mockServicoModel = {
-    findAll: jest.fn(),
-    findByPk: jest.fn(),
-  };
-
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ServicosService,
-        {
-          provide: getModelToken(Servico),
-          useValue: mockServicoModel,
-        },
-      ],
+      providers: [ServicosService], // Como você usa array, não precisa do Mock do Sequelize aqui
     }).compile();
 
     service = module.get<ServicosService>(ServicosService);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
-  it('deve criar um novo serviço', () => {
+  it('deve criar um novo serviço com ID autoincrementado', () => {
     const resultado = service.criarServico(
       'Troca de óleo',
       'Troca completa do óleo do motor',
@@ -45,8 +25,17 @@ describe('ServicosService', () => {
       true,
     );
 
-    expect(resultado).toBeDefined();
-    expect(resultado.nome).toBe('Troca de óleo');
-    expect(resultado.valor_base).toBe(120.5);
+    // Verifica se o objeto retornado tem as propriedades certas
+    expect(resultado).toMatchObject({
+      nome: 'Troca de óleo',
+      descricao: 'Troca completa do óleo do motor',
+      valor_base: 120.5,
+      prazo_estimado_dias: 2,
+      ativo: true,
+    });
+
+    // Verifica se o ID foi gerado corretamente
+    expect(resultado.id).toBeDefined();
+    expect(typeof resultado.id).toBe('number');
   });
 });

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
-import { Servico } from '../../models/servico.model';
+import { Servico } from 'src/models/servico.model';
 @Injectable()
 export class ServicosService {
   constructor(

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -16,7 +16,7 @@ export class ServicosService {
     const servico = await this.servicoModel.findByPk(id);
 
     if (!servico) {
-      throw new NotFoundException(`Servico com id ${id} não encontrado`);
+      throw new NotFoundException(`Serviço com id ${id} não encontrado`);
     }
 
     return servico;

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -1,4 +1,24 @@
-import { Injectable } from '@nestjs/common';
-
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/sequelize';
+import { Servico } from '../../models/servico.model';
 @Injectable()
-export class ServicosService {}
+export class ServicosService {
+  constructor(
+    @InjectModel(Servico)
+    private servicoModel: typeof Servico,
+  ) {}
+
+  async findAll(): Promise<Servico[]> {
+    return this.servicoModel.findAll();
+  }
+
+  async findOne(id: number): Promise<Servico> {
+    const servico = await this.servicoModel.findByPk(id);
+
+    if (!servico) {
+      throw new NotFoundException(`Servico com id ${id} não encontrado`);
+    }
+
+    return servico;
+  }
+}

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -1,4 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
-export class ServicosService {}
+export class ServicosService {
+  constructor(private prisma: PrismaService) {}
+
+  async criarServico(nome: string, descricao?: string) {
+    // validação
+    if (!nome) {
+      throw new BadRequestException('Nome é obrigatório');
+    }
+
+    // criar no banco
+    const servico = await this.prisma.servico.create({
+      data: {
+        nome,
+        descricao,
+      },
+    });
+
+    return servico;
+  }
+}

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -18,7 +18,17 @@ export class ServicosService {
     if (!servico) {
       throw new NotFoundException(`Serviço com id ${id} não encontrado`);
     }
-
     return servico;
+  }
+
+  async updateServico(id: number, dados: Partial<Servico>): Promise<Servico> {
+    const servico = await this.findOne(id);
+    await servico.update(dados);
+    return servico.reload();
+  }
+
+  async deleteServico(id: number): Promise<void> {
+    const servico = await this.findOne(id);
+    await servico.destroy();
   }
 }

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -21,6 +21,7 @@ export class ServicosService {
     prazo_estimado_dias: number,
     ativo: boolean,
   ): Servico {
+    // Validações pedidas pelo Diego
     if (!nome || !descricao) {
       throw new BadRequestException('Nome e descrição são obrigatórios');
     }
@@ -41,7 +42,6 @@ export class ServicosService {
     };
 
     this.servicos.push(novoServico);
-
     return novoServico;
   }
 }

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -1,24 +1,50 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+
+interface Servico {
+  id: number;
+  nome: string;
+  descricao: string;
+  valor_base: number;
+  prazo_estimado_dias: number;
+  ativo: boolean;
+}
 
 @Injectable()
 export class ServicosService {
-  constructor(private prisma: PrismaService) {}
+  private servicos: Servico[] = [];
+  private idAtual = 1;
 
-  async criarServico(nome: string, descricao?: string) {
+  async criarServico(
+    nome: string,
+    descricao: string,
+    valor_base: number,
+    prazo_estimado_dias: number,
+    ativo: boolean,
+  ): Promise<Servico> {
     // validação
-    if (!nome) {
-      throw new BadRequestException('Nome é obrigatório');
+    if (!nome || !descricao) {
+      throw new BadRequestException(
+        'Nome e descrição são obrigatórios',
+      );
     }
 
-    // criar no banco
-    const servico = await this.prisma.servico.create({
-      data: {
-        nome,
-        descricao,
-      },
-    });
+    if (valor_base === undefined || prazo_estimado_dias === undefined) {
+      throw new BadRequestException(
+        'Valor base e prazo estimado são obrigatórios',
+      );
+    }
 
-    return servico;
+    const novoServico: Servico = {
+      id: this.idAtual++,
+      nome,
+      descricao,
+      valor_base,
+      prazo_estimado_dias,
+      ativo,
+    };
+
+    this.servicos.push(novoServico);
+
+    return novoServico;
   }
 }

--- a/src/modules/servicos/servicos.service.ts
+++ b/src/modules/servicos/servicos.service.ts
@@ -14,18 +14,15 @@ export class ServicosService {
   private servicos: Servico[] = [];
   private idAtual = 1;
 
-  async criarServico(
+  criarServico(
     nome: string,
     descricao: string,
     valor_base: number,
     prazo_estimado_dias: number,
     ativo: boolean,
-  ): Promise<Servico> {
-    // validação
+  ): Servico {
     if (!nome || !descricao) {
-      throw new BadRequestException(
-        'Nome e descrição são obrigatórios',
-      );
+      throw new BadRequestException('Nome e descrição são obrigatórios');
     }
 
     if (valor_base === undefined || prazo_estimado_dias === undefined) {

--- a/test/servicos.e2e-spec.ts
+++ b/test/servicos.e2e-spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+
+describe('ServicosController (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET /servicos/abc deve retornar 400', () => {
+    return request(app.getHttpServer()).get('/servicos/abc').expect(400);
+  });
+});


### PR DESCRIPTION
Sua sugestão de melhoria está relacionada a um problema?
Necessidade de implementar a funcionalidade de cadastro de serviços no backend para permitir a persistência de dados no banco através da API.
Descreva a solução que você gostaria de ver implementada
Esta rota é responsável por registrar um novo serviço no sistema. Ao receber a requisição, o sistema deve criar um novo registro de serviço no banco de dados com as informações enviadas.
O sistema deve:
* Validar os dados enviados
* Criar um novo serviço no banco de dados
* Retornar confirmação da criação
* Retornar o status HTTP 201 - Created
Corpo da solicitação
{
"nome": "exemplo",
"descricao": "exemplo"
}
Resposta STATUS 201 – Created
{
"message": "Serviço criado com sucesso"
}
Descreva alternativas que você considerou
Não se aplica, pois a rota POST segue o padrão arquitetural definido para o projeto.
Contexto adicional
Importante:
A implementação desta função exige a atualização do controlador, implementando o método correspondente em servicos.controller.ts para disponibilizar o endpoint: POST/servicos