### PR TITLE
feat: implementa endpoints GET (getAll e getById)

### DIFF
--- a/src/modules/publicidade/publicidade.controller.ts
+++ b/src/modules/publicidade/publicidade.controller.ts
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 import {
   Body,
   Controller,
@@ -27,11 +28,18 @@ import { PublicidadeUpdateDto } from './dto/publicidade-update.dto';
 import { PublicidadeService } from './publicidade.service';
 
 @ApiTags('Publicidade')
+=======
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { PublicidadeService } from './publicidade.service';
+import { Publicidade } from 'src/models/publicidade.model';
+ 
+>>>>>>> Stashed changes
 @Controller('publicidade')
 export class PublicidadeController {
   private readonly logger = new Logger(PublicidadeController.name);
 
   constructor(private readonly publicidadeService: PublicidadeService) {}
+<<<<<<< Updated upstream
 
   @ApiOperation({ summary: 'Criar uma nova publicidade' })
   @ApiResponse({ status: 201, type: PublicidadeResponseDto })
@@ -83,5 +91,17 @@ export class PublicidadeController {
     this.logger.log(`Atualizando publicidade...`);
 
     return this.publicidadeService.update(id, dto, imagem);
+=======
+ 
+  @Get()
+  async getAll(): Promise<Publicidade[]> {
+    return this.publicidadeService.getAll();
+  }
+ 
+  @Get(':id')
+  async getById(@Param('id', ParseIntPipe) id: number): Promise<Publicidade> {
+    return this.publicidadeService.getById(id);
+>>>>>>> Stashed changes
   }
 }
+ 

--- a/src/modules/publicidade/publicidade.service.ts
+++ b/src/modules/publicidade/publicidade.service.ts
@@ -1,15 +1,22 @@
 import {
   Injectable,
+<<<<<<< Updated upstream
   InternalServerErrorException,
+=======
+>>>>>>> Stashed changes
   Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
+<<<<<<< Updated upstream
 import { CloudinaryService } from 'src/infra/cloudinary/cloudinary.service';
 import { CloudinaryResponse } from 'src/infra/cloudinary/dto/cloudinary-response';
 import { Publicidade } from 'src/models/publicidade.model';
 import { PublicidadeCreateDto } from './dto/publicidade-create.dto';
 import { PublicidadeUpdateDto } from './dto/publicidade-update.dto';
+=======
+import { Publicidade } from 'src/models/publicidade.model';
+>>>>>>> Stashed changes
 
 @Injectable()
 export class PublicidadeService {
@@ -18,6 +25,7 @@ export class PublicidadeService {
   constructor(
     @InjectModel(Publicidade)
     private publicidadeModel: typeof Publicidade,
+<<<<<<< Updated upstream
     private readonly cloudinaryService: CloudinaryService,
   ) {}
 
@@ -42,12 +50,24 @@ export class PublicidadeService {
   ): Promise<Publicidade> {
     this.logger.log(`Atualizando publicidade ID: ${id}`);
 
+=======
+  ) {}
+
+  async getAll(): Promise<Publicidade[]> {
+    this.logger.log('Buscando todas as publicidades...');
+    return this.publicidadeModel.findAll();
+  }
+
+  async getById(id: number): Promise<Publicidade> {
+    this.logger.log(`Buscando publicidade com ID: ${id}`);
+>>>>>>> Stashed changes
     const publicidade = await this.publicidadeModel.findByPk(id);
 
     if (!publicidade) {
       throw new NotFoundException('Publicidade não encontrada');
     }
 
+<<<<<<< Updated upstream
     const updateData: Partial<Publicidade> = { ...dto };
 
     if (file) {
@@ -72,3 +92,8 @@ export class PublicidadeService {
     });
   }
 }
+=======
+    return publicidade;
+  }
+}
+>>>>>>> Stashed changes


### PR DESCRIPTION
Abrindo esse PR para implementar os endpoints GET do módulo de publicidade, conforme alinhado.

Como havia um conflito de merge na branch anterior (feature/publicidade-get), optei por criar um PR limpo para facilitar o review e evitar ruído no histórico.


✅ O que foi feito:
• GET /publicidade → retorna todas as publicidades cadastradas
• GET /publicidade/:id → retorna uma publicidade pelo ID, com NotFoundException caso não encontrada


Qualquer dúvida ou ajuste, é só falar. 