### PR TITLE
feat: Adiciona campo ativo em publicidade e rota para buscar publicid…

### DIFF
--- a/src/models/publicidade.model.ts
+++ b/src/models/publicidade.model.ts
@@ -13,4 +13,11 @@ export class Publicidade extends Model {
 
   @Column({ field: 'url_imagem', type: DataType.STRING(255), allowNull: true })
   declare urlImagem: string | null;
+
+  @Column({
+    type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: true,
+  })
+  declare ativo: boolean;
 }

--- a/src/modules/publicidade/dto/publicidade-create.dto.ts
+++ b/src/modules/publicidade/dto/publicidade-create.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class PublicidadeCreateDto {
   @IsString()
@@ -13,6 +14,16 @@ export class PublicidadeCreateDto {
     example: 'Proteja seu veiculo com nosso parceiro credenciado.',
   })
   conteudo: string;
+
+  @ApiProperty({
+    example: 'true',
+    required: false,
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  ativo?: boolean;
 }
 
 export class PublicidadeResponseDto {
@@ -27,4 +38,7 @@ export class PublicidadeResponseDto {
 
   @ApiProperty()
   urlImagem: string;
+
+  @ApiProperty()
+  ativo: boolean;
 }

--- a/src/modules/publicidade/dto/publicidade-update.dto.ts
+++ b/src/modules/publicidade/dto/publicidade-update.dto.ts
@@ -1,5 +1,6 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 
 export class PublicidadeUpdateDto {
   @ApiProperty({
@@ -19,4 +20,14 @@ export class PublicidadeUpdateDto {
   @IsOptional()
   @IsString()
   conteudo?: string;
+
+  @ApiProperty({
+    example: 'true',
+    required: false,
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  ativo?: boolean;
 }

--- a/src/modules/publicidade/publicidade.controller.ts
+++ b/src/modules/publicidade/publicidade.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -51,6 +52,21 @@ export class PublicidadeController {
     return this.publicidadeService.getById(id);
   }
 
+  @Get('/status/:status')
+  @ApiOperation({ summary: 'Buscar publicidade por status (ativo, inativo)' })
+  @ApiResponse({ status: 200, type: PublicidadeResponseDto })
+  getByStatus(@Param('status') status: string): Promise<Publicidade[]> {
+    this.logger.log(`Buscando publicidade por status: ${status}`);
+    if (status !== 'ativo' && status !== 'inativo') {
+      throw new BadRequestException(
+        "Status inválido. Use 'ativo' ou 'inativo'.",
+      );
+    }
+    return this.publicidadeService.getByStatus(
+      status === 'ativo' ? true : false,
+    );
+  }
+
   @ApiOperation({ summary: 'Criar uma nova publicidade' })
   @ApiResponse({ status: 201, type: PublicidadeResponseDto })
   @ApiBody({
@@ -61,6 +77,11 @@ export class PublicidadeController {
         conteudo: {
           type: 'string',
           example: 'Proteja seu veiculo com nosso parceiro credenciado.',
+        },
+        ativo: {
+          type: 'boolean',
+          example: true,
+          default: true,
         },
         file: { type: 'string', format: 'binary' },
       },
@@ -87,6 +108,7 @@ export class PublicidadeController {
       properties: {
         titulo: { type: 'string', nullable: true },
         conteudo: { type: 'string', nullable: true },
+        ativo: { type: 'boolean', nullable: true },
         imagem: { type: 'string', format: 'binary' },
       },
     },

--- a/src/modules/publicidade/publicidade.service.ts
+++ b/src/modules/publicidade/publicidade.service.ts
@@ -52,6 +52,14 @@ export class PublicidadeService {
     return publicidade;
   }
 
+  async getByStatus(ativo: boolean): Promise<Publicidade[]> {
+    this.logger.log(
+      `Buscando publicidades por status: ${ativo ? 'ativo' : 'inativo'}`,
+    );
+
+    return this.publicidadeModel.findAll({ where: { ativo } });
+  }
+
   async update(
     id: number,
     dto: PublicidadeUpdateDto,


### PR DESCRIPTION
Adiciona campo 'ativo'  na publicidade.

Criei a rota /publicidade/status/:status
Exemplo: 
``` bash
curl -X 'GET' \
  'http://localhost:3000/publicidade/status/inativo' \
  -H 'accept: application/json'
``` 

Essa mudança não possui issue criada.