### PR TITLE
feat: implementa rota de post na tabela interacao_usuario

### DIFF
--- a/src/models/interacao-usuario.model.ts
+++ b/src/models/interacao-usuario.model.ts
@@ -1,0 +1,43 @@
+import {
+  BelongsTo,
+  Column,
+  DataType,
+  ForeignKey,
+  Model,
+  Table,
+} from 'sequelize-typescript';
+import { RecomendacaoCategoriaBlogEnum } from 'src/modules/recomendacao/enums/recomendacao-categoria-blog.enum';
+import { Usuario } from './usuario.model';
+
+@Table({ tableName: 'interacao_usuario' })
+export class InteracaoUsuario extends Model {
+  @Column({ primaryKey: true, autoIncrement: true, allowNull: false })
+  declare id: number;
+
+  @ForeignKey(() => Usuario)
+  @Column({ field: 'usuario_id', allowNull: false })
+  declare usuarioId: number;
+
+  @BelongsTo(() => Usuario)
+  declare usuario: Usuario;
+
+  @Column({
+    field: 'categoria_blog',
+    type: DataType.ENUM(
+      RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+      RecomendacaoCategoriaBlogEnum.DEBITOS,
+      RecomendacaoCategoriaBlogEnum.MULTAS,
+      RecomendacaoCategoriaBlogEnum.LEGISLACAO,
+      RecomendacaoCategoriaBlogEnum.CONDUTOR,
+    ),
+    allowNull: false,
+  })
+  declare categoriaBlog: RecomendacaoCategoriaBlogEnum;
+
+  @Column({
+    field: 'data_interacao',
+    type: DataType.DATEONLY,
+    allowNull: false,
+  })
+  declare dataInteracao: Date;
+}

--- a/src/modules/recomendacao/dto/recomendacao-interacao-request.dto.ts
+++ b/src/modules/recomendacao/dto/recomendacao-interacao-request.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsEnum } from 'class-validator';
+import { RecomendacaoCategoriaBlogEnum } from '../enums/recomendacao-categoria-blog.enum';
+
+// DTO de request da rota POST
+export class RecomendacaoInteracaoRequestDto {
+  @ApiProperty({
+    example: 'Documentacao',
+    enum: RecomendacaoCategoriaBlogEnum,
+  })
+  @IsEnum(RecomendacaoCategoriaBlogEnum)
+  categoriaBlog!: RecomendacaoCategoriaBlogEnum;
+
+  @ApiProperty({ example: '2024-05-20' })
+  @IsDateString()
+  dataInteracao!: string;
+}

--- a/src/modules/recomendacao/dto/recomendacao-interacao-response.dto.ts
+++ b/src/modules/recomendacao/dto/recomendacao-interacao-response.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { RecomendacaoCategoriaBlogEnum } from '../enums/recomendacao-categoria-blog.enum';
+
+// DTO de resposta da API da rota POST
+export class RecomendacaoInteracaoResponseDto {
+  @ApiProperty({ example: 1, description: 'Id da interação registrada' })
+  id!: number;
+
+  @ApiProperty({ example: 1, description: 'Id do usuário da interação' })
+  usuarioId!: number;
+
+  @ApiProperty({
+    example: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+    enum: RecomendacaoCategoriaBlogEnum,
+    description: 'Categoria do blog associada à interação',
+  })
+  categoriaBlog!: RecomendacaoCategoriaBlogEnum;
+
+  @ApiProperty({
+    example: '2024-05-20',
+    description: 'Data da interação no formato YYYY-MM-DD',
+  })
+  dataInteracao!: string;
+}

--- a/src/modules/recomendacao/enums/recomendacao-categoria-blog.enum.ts
+++ b/src/modules/recomendacao/enums/recomendacao-categoria-blog.enum.ts
@@ -1,0 +1,7 @@
+export enum RecomendacaoCategoriaBlogEnum {
+  DOCUMENTACAO = 'Documentacao',
+  DEBITOS = 'Debitos',
+  MULTAS = 'Multas',
+  LEGISLACAO = 'Legislacao',
+  CONDUTOR = 'Condutor',
+}

--- a/src/modules/recomendacao/recomendacao.controller.spec.ts
+++ b/src/modules/recomendacao/recomendacao.controller.spec.ts
@@ -4,16 +4,33 @@ import { RecomendacaoService } from './recomendacao.service';
 import { getModelToken } from '@nestjs/sequelize';
 import { Servico } from 'src/models/servico.model';
 import { Solicitacao } from 'src/models/solicitacao.model';
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { RecomendacaoInteracaoRequestDto } from './dto/recomendacao-interacao-request.dto';
+import { RecomendacaoInteracaoResponseDto } from './dto/recomendacao-interacao-response.dto';
+import { RecomendacaoCategoriaBlogEnum } from './enums/recomendacao-categoria-blog.enum';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 describe('RecomendacaoController', () => {
   let controller: RecomendacaoController;
+
+  const mockRecomendacaoService = {
+    criarInteracao: jest.fn() as jest.MockedFunction<
+      (
+        usuarioId: number,
+        interacaoDto: RecomendacaoInteracaoRequestDto,
+      ) => Promise<RecomendacaoInteracaoResponseDto>
+    >,
+    buscarAtributosPerfil: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RecomendacaoController],
       providers: [
         RecomendacaoService,
+        {
+          provide: RecomendacaoService,
+          useValue: mockRecomendacaoService,
+        },
         {
           provide: getModelToken(Servico),
           useValue: {},
@@ -26,9 +43,33 @@ describe('RecomendacaoController', () => {
     }).compile();
 
     controller = module.get<RecomendacaoController>(RecomendacaoController);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('deve criar interação com o blog', async () => {
+    const interacaoDto: RecomendacaoInteracaoRequestDto = {
+      categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+      dataInteracao: '2024-05-20',
+    };
+    // const req = { user: { id: 1 } };
+
+    mockRecomendacaoService.criarInteracao.mockResolvedValue({
+      id: 1,
+      usuarioId: 1,
+      categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+      dataInteracao: '2024-05-20',
+    } as RecomendacaoInteracaoResponseDto);
+
+    await controller.criarInteracao(interacaoDto);
+
+    expect(mockRecomendacaoService.criarInteracao).toHaveBeenCalledWith(
+      1,
+      interacaoDto,
+    );
   });
 });

--- a/src/modules/recomendacao/recomendacao.controller.ts
+++ b/src/modules/recomendacao/recomendacao.controller.ts
@@ -1,7 +1,48 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Logger, Post } from '@nestjs/common';
+import { ApiBody, ApiOperation } from '@nestjs/swagger';
+import { RecomendacaoInteracaoRequestDto } from './dto/recomendacao-interacao-request.dto';
+import { RecomendacaoInteracaoResponseDto } from './dto/recomendacao-interacao-response.dto';
 import { RecomendacaoService } from './recomendacao.service';
 
 @Controller('recomendacao')
 export class RecomendacaoController {
+  private readonly logger = new Logger(RecomendacaoController.name);
   constructor(private readonly recomendacaoService: RecomendacaoService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Registrar interação do usuário com o blog' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        categoriaBlog: {
+          type: 'string',
+          enum: ['Documentacao', 'Debitos', 'Multas', 'Legislacao', 'Condutor'],
+          example: 'Documentacao',
+        },
+        dataInteracao: {
+          type: 'string',
+          format: 'date',
+          example: '2024-05-20',
+        },
+      },
+      required: ['categoriaBlog', 'dataInteracao'],
+    },
+  })
+  criarInteracao(
+    // @Req() req: Request & { user?: { id?: number } },
+    @Body() interacaoDto: RecomendacaoInteracaoRequestDto,
+  ): Promise<RecomendacaoInteracaoResponseDto> {
+    // const usuarioId = req.user?.id;
+    // if (!usuarioId) {
+    //   throw new UnauthorizedException('Usuário não autenticado.');
+    // }
+    const usuarioId = 1;
+
+    this.logger.log(
+      `Registrando interação do usuário ${usuarioId} com blog na categoria ${interacaoDto.categoriaBlog}`,
+    );
+
+    return this.recomendacaoService.criarInteracao(usuarioId, interacaoDto);
+  }
 }

--- a/src/modules/recomendacao/recomendacao.module.ts
+++ b/src/modules/recomendacao/recomendacao.module.ts
@@ -1,8 +1,25 @@
 import { Module } from '@nestjs/common';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { CloudinaryModule } from 'src/infra/cloudinary/cloudinary.module';
+import { InteracaoUsuario } from 'src/models/interacao-usuario.model';
+import { Servico } from 'src/models/servico.model';
+import { Solicitacao } from 'src/models/solicitacao.model';
+import { Usuario } from 'src/models/usuario.model';
+import { Veiculo } from 'src/models/veiculo.model';
 import { RecomendacaoService } from './recomendacao.service';
 import { RecomendacaoController } from './recomendacao.controller';
 
 @Module({
+  imports: [
+    SequelizeModule.forFeature([
+      Servico,
+      Solicitacao,
+      Usuario,
+      Veiculo,
+      InteracaoUsuario,
+    ]),
+    CloudinaryModule,
+  ],
   controllers: [RecomendacaoController],
   providers: [RecomendacaoService],
 })

--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -1,10 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/sequelize';
 import { RecomendacaoService } from './recomendacao.service';
+import { InteracaoUsuario } from 'src/models/interacao-usuario.model';
 import { Servico } from 'src/models/servico.model';
 import { Solicitacao } from 'src/models/solicitacao.model';
 import { InternalServerErrorException } from '@nestjs/common';
 import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { RecomendacaoInteracaoRequestDto } from './dto/recomendacao-interacao-request.dto';
+import { RecomendacaoInteracaoResponseDto } from './dto/recomendacao-interacao-response.dto';
+import { RecomendacaoCategoriaBlogEnum } from './enums/recomendacao-categoria-blog.enum';
 import { SolicitacaoComServicoDto } from './dto/solicitacao-com-servico.dto';
 
 describe('RecomendacaoService', () => {
@@ -18,6 +22,16 @@ describe('RecomendacaoService', () => {
 
   const mockServicoModel = {};
 
+  const mockInteracaoUsuarioModel = {
+    create: jest.fn() as jest.MockedFunction<
+      (interacaoRegistro: {
+        usuarioId: number;
+        categoriaBlog: RecomendacaoCategoriaBlogEnum;
+        dataInteracao: string;
+      }) => Promise<RecomendacaoInteracaoResponseDto>
+    >,
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
@@ -30,6 +44,10 @@ describe('RecomendacaoService', () => {
         {
           provide: getModelToken(Servico),
           useValue: mockServicoModel,
+        },
+        {
+          provide: getModelToken(InteracaoUsuario),
+          useValue: mockInteracaoUsuarioModel,
         },
       ],
     }).compile();
@@ -90,6 +108,55 @@ describe('RecomendacaoService', () => {
       await expect(service.buscarAtributosPerfil(1)).rejects.toThrow(
         InternalServerErrorException,
       );
+    });
+  });
+
+  describe('criarInteracao', () => {
+    it('deve registrar a interação com o blog', async () => {
+      const usuarioId = 1;
+      const interacaoDto: RecomendacaoInteracaoRequestDto = {
+        categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+        dataInteracao: '2024-05-20',
+      };
+
+      mockInteracaoUsuarioModel.create.mockResolvedValue({
+        id: 7,
+        usuarioId,
+        categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+        dataInteracao: '2024-05-20',
+      });
+
+      const resultado = await service.criarInteracao(usuarioId, interacaoDto);
+
+      expect(mockInteracaoUsuarioModel.create).toHaveBeenCalledWith({
+        usuarioId,
+        categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+        dataInteracao: '2024-05-20',
+      });
+      expect(resultado).toEqual(
+        expect.objectContaining({
+          id: 7,
+          usuarioId,
+          categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+          dataInteracao: '2024-05-20',
+        }),
+      );
+    });
+
+    it('deve lançar InternalServerErrorException quando houver falha técnica', async () => {
+      const usuarioId = 1;
+      const interacaoDto: RecomendacaoInteracaoRequestDto = {
+        categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+        dataInteracao: '2024-05-20',
+      };
+
+      mockInteracaoUsuarioModel.create.mockRejectedValue(
+        new Error('Falha de gravação'),
+      );
+
+      await expect(
+        service.criarInteracao(usuarioId, interacaoDto),
+      ).rejects.toThrow(InternalServerErrorException);
     });
   });
 });

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -4,8 +4,11 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
+import { InteracaoUsuario } from 'src/models/interacao-usuario.model';
 import { Servico } from 'src/models/servico.model';
 import { Solicitacao } from 'src/models/solicitacao.model';
+import { RecomendacaoInteracaoRequestDto } from './dto/recomendacao-interacao-request.dto';
+import { RecomendacaoInteracaoResponseDto } from './dto/recomendacao-interacao-response.dto';
 import { PerfilUsuarioDto } from './dto/recomendacao-perfil-usuario.dto';
 import { SolicitacaoComServicoDto } from './dto/solicitacao-com-servico.dto';
 
@@ -18,7 +21,48 @@ export class RecomendacaoService {
     private servicoModel: typeof Servico,
     @InjectModel(Solicitacao)
     private solicitacaoModel: typeof Solicitacao,
+    @InjectModel(InteracaoUsuario)
+    private interacaoUsuarioModel: typeof InteracaoUsuario,
   ) {}
+
+  async criarInteracao(
+    usuarioId: number,
+    interacaoDto: RecomendacaoInteracaoRequestDto,
+  ): Promise<RecomendacaoInteracaoResponseDto> {
+    try {
+      this.logger.log(
+        `Registrando interação do usuário ${usuarioId} na categoria ${interacaoDto.categoriaBlog}`,
+      );
+
+      const interacao = await this.interacaoUsuarioModel.create({
+        usuarioId,
+        categoriaBlog: interacaoDto.categoriaBlog,
+        dataInteracao: interacaoDto.dataInteracao,
+      });
+
+      this.logger.log(
+        `Interação registrada com sucesso. ID ${interacao.id} para usuário ${usuarioId}`,
+      );
+
+      return {
+        id: interacao.id,
+        usuarioId,
+        categoriaBlog: interacao.categoriaBlog,
+        dataInteracao: String(interacao.dataInteracao),
+      };
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erro desconhecido';
+
+      this.logger.error(
+        `Falha ao salvar interação do usuário ${usuarioId}: ${errorMessage}`,
+      );
+
+      throw new InternalServerErrorException(
+        'Não foi possível registrar a interação com o blog neste momento.',
+      );
+    }
+  }
 
   async buscarAtributosPerfil(usuarioId: number): Promise<PerfilUsuarioDto[]> {
     try {


### PR DESCRIPTION
Rota POST para registrar interações de usuários com categorias de blog. Nos próximos passos, para recomendar o serviço "Comunicação de Venda", basta consultar essa tabela

Para conseguir testar a rota de recomendação antes da autenticação estar pronta, o `usuarioId` está mockado no controller (`usuarioId = 1`)

A parte de pegar o usuário da sessão já está no código, só ficou comentada

Quando o auth/login for implementado:
- descomentar o trecho que pega `req.user.id`
- remover o `usuarioId` mockado

closes #153 