### PR TITLE
feat: implementar rota de recomendações com lógica de exclusão e popu…

### DIFF
--- a/src/modules/recomendacao/dto/recomendacao-perfil-usuario.dto.ts
+++ b/src/modules/recomendacao/dto/recomendacao-perfil-usuario.dto.ts
@@ -1,4 +1,5 @@
 export class PerfilUsuarioDto {
+  id!: number;
   nome!: string;
   descricao!: string;
   valor_base!: number;

--- a/src/modules/recomendacao/dto/recomendacao-resposta.dto.ts
+++ b/src/modules/recomendacao/dto/recomendacao-resposta.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RecomendacaoRespostaDto {
+  @ApiProperty({ 
+    example: 7, 
+    description: 'ID identificador do serviço' 
+  })
+  id!: number;
+
+  @ApiProperty({ 
+    example: 'Licenciamento Anual (CRLV-e)', 
+    description: 'Nome do serviço automotivo' 
+  })
+  nome!: string;
+
+  @ApiProperty({ 
+    example: 'Processo de renovação do documento do veículo para circulação regular.', 
+    description: 'Descrição detalhada para o usuário' 
+  })
+  descricao!: string;
+
+  @ApiProperty({ 
+    example: true, 
+    description: 'Status do serviço no catálogo' 
+  })
+  ativo!: boolean;
+}

--- a/src/modules/recomendacao/dto/recomendacao-resposta.dto.ts
+++ b/src/modules/recomendacao/dto/recomendacao-resposta.dto.ts
@@ -1,27 +1,29 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+// DTO de resposta da API da rota GET
 export class RecomendacaoRespostaDto {
-  @ApiProperty({ 
-    example: 7, 
-    description: 'ID identificador do serviço' 
+  @ApiProperty({
+    example: 7,
+    description: 'ID identificador do serviço',
   })
   id!: number;
 
-  @ApiProperty({ 
-    example: 'Licenciamento Anual (CRLV-e)', 
-    description: 'Nome do serviço automotivo' 
+  @ApiProperty({
+    example: 'Licenciamento Anual (CRLV-e)',
+    description: 'Nome do serviço automotivo',
   })
   nome!: string;
 
-  @ApiProperty({ 
-    example: 'Processo de renovação do documento do veículo para circulação regular.', 
-    description: 'Descrição detalhada para o usuário' 
+  @ApiProperty({
+    example:
+      'Processo de renovação do documento do veículo para circulação regular.',
+    description: 'Descrição detalhada para o usuário',
   })
   descricao!: string;
 
-  @ApiProperty({ 
-    example: true, 
-    description: 'Status do serviço no catálogo' 
+  @ApiProperty({
+    example: true,
+    description: 'Status do serviço no catálogo',
   })
   ativo!: boolean;
 }

--- a/src/modules/recomendacao/dto/solicitacao-com-servico.dto.ts
+++ b/src/modules/recomendacao/dto/solicitacao-com-servico.dto.ts
@@ -1,5 +1,6 @@
 export class SolicitacaoComServicoDto {
   servico!: {
+    id: number;
     nome: string;
     descricao: string;
     valor_base: number;

--- a/src/modules/recomendacao/recomendacao.controller.spec.ts
+++ b/src/modules/recomendacao/recomendacao.controller.spec.ts
@@ -1,34 +1,66 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RecomendacaoController } from './recomendacao.controller';
 import { RecomendacaoService } from './recomendacao.service';
-import { getModelToken } from '@nestjs/sequelize';
-import { Servico } from 'src/models/servico.model';
-import { Solicitacao } from 'src/models/solicitacao.model';
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { RecomendacaoRespostaDto } from './dto/recomendacao-resposta.dto';
+import { InternalServerErrorException } from '@nestjs/common';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 
 describe('RecomendacaoController', () => {
   let controller: RecomendacaoController;
+  let service: RecomendacaoService;
+
+  const mockRecomendacaoService = {
+    obterRecomendacoes: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RecomendacaoController],
       providers: [
-        RecomendacaoService,
         {
-          provide: getModelToken(Servico),
-          useValue: {},
-        },
-        {
-          provide: getModelToken(Solicitacao),
-          useValue: {},
+          provide: RecomendacaoService,
+          useValue: mockRecomendacaoService,
         },
       ],
     }).compile();
 
     controller = module.get<RecomendacaoController>(RecomendacaoController);
+    service = module.get<RecomendacaoService>(RecomendacaoService);
   });
 
-  it('should be defined', () => {
+  it('deve estar definido', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getRecomendacao', () => {
+    it('deve retornar uma lista de recomendações com sucesso', async () => {
+      // Dados de exemplo que o Service "fingiria" retornar
+      const mockResult: RecomendacaoRespostaDto[] = [
+        {
+          id: 7,
+          nome: 'Licenciamento Anual (CRLV-e)',
+          descricao: 'Processo de renovação do documento do veículo.',
+          ativo: true,
+        },
+      ];
+
+      mockRecomendacaoService.obterRecomendacoes.mockResolvedValue(mockResult);
+
+      const resultado = await controller.getRecomendacao(1);
+
+      expect(resultado).toEqual(mockResult);
+      expect(mockRecomendacaoService.obterRecomendacoes).toHaveBeenCalledWith(1);
+      expect(mockRecomendacaoService.obterRecomendacoes).toHaveBeenCalledTimes(1);
+    });
+
+    it('deve repassar exceções do service (ex: erro 500)', async () => {
+      mockRecomendacaoService.obterRecomendacoes.mockRejectedValue(
+        new InternalServerErrorException('Erro no servidor'),
+      );
+
+      await expect(controller.getRecomendacao(1)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
   });
 });

--- a/src/modules/recomendacao/recomendacao.controller.spec.ts
+++ b/src/modules/recomendacao/recomendacao.controller.spec.ts
@@ -1,33 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { RecomendacaoController } from './recomendacao.controller';
 import { RecomendacaoService } from './recomendacao.service';
 import { RecomendacaoRespostaDto } from './dto/recomendacao-resposta.dto';
-import { InternalServerErrorException } from '@nestjs/common';
-import { jest, describe, it, expect, beforeEach } from '@jest/globals';
-import { getModelToken } from '@nestjs/sequelize';
-import { Servico } from 'src/models/servico.model';
-import { Solicitacao } from 'src/models/solicitacao.model';
 import { RecomendacaoInteracaoRequestDto } from './dto/recomendacao-interacao-request.dto';
 import { RecomendacaoInteracaoResponseDto } from './dto/recomendacao-interacao-response.dto';
 import { RecomendacaoCategoriaBlogEnum } from './enums/recomendacao-categoria-blog.enum';
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 
 describe('RecomendacaoController', () => {
   let controller: RecomendacaoController;
-  let service: RecomendacaoService;
 
   const mockRecomendacaoService = {
-    obterRecomendacoes: jest.fn(),
-  };
-
-  const mockRecomendacaoService = {
+    obterRecomendacoes: jest.fn() as jest.MockedFunction<
+      (usuarioId: number) => Promise<RecomendacaoRespostaDto[]>
+    >,
     criarInteracao: jest.fn() as jest.MockedFunction<
       (
         usuarioId: number,
         interacaoDto: RecomendacaoInteracaoRequestDto,
       ) => Promise<RecomendacaoInteracaoResponseDto>
     >,
-    buscarAtributosPerfil: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -39,30 +32,20 @@ describe('RecomendacaoController', () => {
           provide: RecomendacaoService,
           useValue: mockRecomendacaoService,
         },
-        {
-          provide: getModelToken(Servico),
-          useValue: {},
-        },
-        {
-          provide: RecomendacaoService,
-          useValue: mockRecomendacaoService,
-        },
       ],
     }).compile();
 
     controller = module.get<RecomendacaoController>(RecomendacaoController);
-    service = module.get<RecomendacaoService>(RecomendacaoService);
-
     jest.clearAllMocks();
   });
 
-  it('deve estar definido', () => {
+  it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
   describe('getRecomendacao', () => {
     it('deve retornar uma lista de recomendações com sucesso', async () => {
-      // Dados de exemplo que o Service "fingiria" retornar
+      const mockUsuarioId = 1;
       const mockResult: RecomendacaoRespostaDto[] = [
         {
           id: 7,
@@ -74,11 +57,15 @@ describe('RecomendacaoController', () => {
 
       mockRecomendacaoService.obterRecomendacoes.mockResolvedValue(mockResult);
 
-      const resultado = await controller.getRecomendacao(1);
+      const resultado = await controller.getRecomendacao(mockUsuarioId);
 
       expect(resultado).toEqual(mockResult);
-      expect(mockRecomendacaoService.obterRecomendacoes).toHaveBeenCalledWith(1);
-      expect(mockRecomendacaoService.obterRecomendacoes).toHaveBeenCalledTimes(1);
+      expect(mockRecomendacaoService.obterRecomendacoes).toHaveBeenCalledWith(
+        mockUsuarioId,
+      );
+      expect(mockRecomendacaoService.obterRecomendacoes).toHaveBeenCalledTimes(
+        1,
+      );
     });
 
     it('deve repassar exceções do service (ex: erro 500)', async () => {
@@ -91,26 +78,31 @@ describe('RecomendacaoController', () => {
       );
     });
   });
-});
-  it('deve criar interação com o blog', async () => {
-    const interacaoDto: RecomendacaoInteracaoRequestDto = {
-      categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
-      dataInteracao: '2024-05-20',
-    };
-    // const req = { user: { id: 1 } };
 
-    mockRecomendacaoService.criarInteracao.mockResolvedValue({
-      id: 1,
-      usuarioId: 1,
-      categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
-      dataInteracao: '2024-05-20',
-    } as RecomendacaoInteracaoResponseDto);
+  describe('criarInteracao', () => {
+    it('deve criar interação com o blog', async () => {
+      const usuarioId = 1;
+      const interacaoDto: RecomendacaoInteracaoRequestDto = {
+        categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+        dataInteracao: '2024-05-20',
+      };
+      // const req = { user: { id: usuarioId } };
 
-    await controller.criarInteracao(interacaoDto);
+      mockRecomendacaoService.criarInteracao.mockResolvedValue({
+        id: 7,
+        usuarioId: usuarioId,
+        categoriaBlog: RecomendacaoCategoriaBlogEnum.DOCUMENTACAO,
+        dataInteracao: '2024-05-20',
+      } as RecomendacaoInteracaoResponseDto);
 
-    expect(mockRecomendacaoService.criarInteracao).toHaveBeenCalledWith(
-      1,
-      interacaoDto,
-    );
+      const resultado = await controller.criarInteracao(interacaoDto);
+      // const resultado = await controller.criarInteracao(req, interacaoDto);
+
+      expect(mockRecomendacaoService.criarInteracao).toHaveBeenCalledWith(
+        usuarioId,
+        interacaoDto,
+      );
+      expect(resultado.usuarioId).toBe(usuarioId);
+    });
   });
 });

--- a/src/modules/recomendacao/recomendacao.controller.ts
+++ b/src/modules/recomendacao/recomendacao.controller.ts
@@ -1,7 +1,24 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { ApiTags, ApiResponse, ApiOperation } from '@nestjs/swagger';
 import { RecomendacaoService } from './recomendacao.service';
+import { RecomendacaoRespostaDto } from './dto/recomendacao-resposta.dto';
 
-@Controller('recomendacao')
+@ApiTags('Recomendações')
+@Controller('recomendacoes')
 export class RecomendacaoController {
   constructor(private readonly recomendacaoService: RecomendacaoService) {}
+
+  @Get(':usuarioId')
+  @ApiOperation({ summary: 'Gera recomendações de serviços para o usuário' })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de serviços recomendados retornada com sucesso.',
+    type: RecomendacaoRespostaDto,
+    isArray: true, 
+  })
+  async getRecomendacao(
+    @Param('usuarioId', ParseIntPipe) usuarioId: number,
+  ) {
+    return await this.recomendacaoService.obterRecomendacoes(usuarioId);
+  }
 }

--- a/src/modules/recomendacao/recomendacao.controller.ts
+++ b/src/modules/recomendacao/recomendacao.controller.ts
@@ -1,7 +1,13 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
-import { ApiTags, ApiResponse, ApiOperation } from '@nestjs/swagger';
-import { Body, Controller, Logger, Post } from '@nestjs/common';
-import { ApiBody, ApiOperation } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  ParseIntPipe,
+  Post,
+} from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { RecomendacaoInteracaoRequestDto } from './dto/recomendacao-interacao-request.dto';
 import { RecomendacaoInteracaoResponseDto } from './dto/recomendacao-interacao-response.dto';
 import { RecomendacaoService } from './recomendacao.service';
@@ -19,14 +25,12 @@ export class RecomendacaoController {
     status: 200,
     description: 'Lista de serviços recomendados retornada com sucesso.',
     type: RecomendacaoRespostaDto,
-    isArray: true, 
+    isArray: true,
   })
-  async getRecomendacao(
-    @Param('usuarioId', ParseIntPipe) usuarioId: number,
-  ) {
-    return await this.recomendacaoService.obterRecomendacoes(usuarioId);
+  async getRecomendacao(@Param('usuarioId', ParseIntPipe) usuarioId: number) {
+    return this.recomendacaoService.obterRecomendacoes(usuarioId);
   }
-}
+
   @Post()
   @ApiOperation({ summary: 'Registrar interação do usuário com o blog' })
   @ApiBody({
@@ -51,6 +55,8 @@ export class RecomendacaoController {
     // @Req() req: Request & { user?: { id?: number } },
     @Body() interacaoDto: RecomendacaoInteracaoRequestDto,
   ): Promise<RecomendacaoInteracaoResponseDto> {
+    // import de @nestjs/common: Req, UnauthorizedException
+    // import { Request } from 'express';
     // const usuarioId = req.user?.id;
     // if (!usuarioId) {
     //   throw new UnauthorizedException('Usuário não autenticado.');

--- a/src/modules/recomendacao/recomendacao.module.ts
+++ b/src/modules/recomendacao/recomendacao.module.ts
@@ -1,8 +1,16 @@
 import { Module } from '@nestjs/common';
 import { RecomendacaoService } from './recomendacao.service';
 import { RecomendacaoController } from './recomendacao.controller';
+import { SequelizeModule } from '@nestjs/sequelize';
+import { Servico } from 'src/models/servico.model';
+import { Solicitacao } from 'src/models/solicitacao.model';
+import { Usuario } from 'src/models/usuario.model';
+import { Veiculo } from 'src/models/veiculo.model';
 
 @Module({
+  imports: [
+    SequelizeModule.forFeature([Servico, Solicitacao, Usuario, Veiculo]), 
+  ],
   controllers: [RecomendacaoController],
   providers: [RecomendacaoService],
 })

--- a/src/modules/recomendacao/recomendacao.module.ts
+++ b/src/modules/recomendacao/recomendacao.module.ts
@@ -1,11 +1,6 @@
 import { Module } from '@nestjs/common';
-import { SequelizeModule } from '@nestjs/sequelize';
 import { CloudinaryModule } from 'src/infra/cloudinary/cloudinary.module';
 import { InteracaoUsuario } from 'src/models/interacao-usuario.model';
-import { Servico } from 'src/models/servico.model';
-import { Solicitacao } from 'src/models/solicitacao.model';
-import { Usuario } from 'src/models/usuario.model';
-import { Veiculo } from 'src/models/veiculo.model';
 import { RecomendacaoService } from './recomendacao.service';
 import { RecomendacaoController } from './recomendacao.controller';
 import { SequelizeModule } from '@nestjs/sequelize';
@@ -16,7 +11,7 @@ import { Veiculo } from 'src/models/veiculo.model';
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([Servico, Solicitacao, Usuario, Veiculo]), 
+    SequelizeModule.forFeature([Servico, Solicitacao, Usuario, Veiculo]),
     SequelizeModule.forFeature([
       Servico,
       Solicitacao,

--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -62,6 +62,7 @@ describe('RecomendacaoService', () => {
       const mockDbResponse: SolicitacaoComServicoDto[] = [
         {
           servico: {
+            id: 1,
             nome: 'Transferência de Propriedade',
             descricao: 'Mudança de propriedade de veículo',
             valor_base: 350.0,
@@ -70,6 +71,7 @@ describe('RecomendacaoService', () => {
         },
         {
           servico: {
+            id: 2,
             nome: 'Licenciamento Anual',
             descricao: 'Taxa de licenciamento',
             valor_base: 180.0,

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -8,6 +8,7 @@ import { Servico } from 'src/models/servico.model';
 import { Solicitacao } from 'src/models/solicitacao.model';
 import { PerfilUsuarioDto } from './dto/recomendacao-perfil-usuario.dto';
 import { SolicitacaoComServicoDto } from './dto/solicitacao-com-servico.dto';
+import { Op, fn, col, literal } from 'sequelize';
 
 @Injectable()
 export class RecomendacaoService {
@@ -20,6 +21,58 @@ export class RecomendacaoService {
     private solicitacaoModel: typeof Solicitacao,
   ) {}
 
+  async obterRecomendacoes(usuarioId: number) {
+    try {
+      const historico = await this.buscarAtributosPerfil(usuarioId);
+
+      if (historico.length > 0) {
+        const idsUsados  = historico.map(s => s.id);
+        
+        const servicos = await this.servicoModel.findAll({
+          where: {
+            ativo: true,
+            id: { [Op.notIn]: idsUsados }
+          }
+        });
+
+        return servicos.map(s => ({
+          id: s.id,
+          nome: s.nome,
+          descricao: s.descricao,
+        }));
+      }
+
+      return await this.buscarServicosPopulares();
+
+    } catch (error) {
+      this.logger.error(`Erro ao gerar recomendações: ${error.message}`);
+      throw new InternalServerErrorException('Erro no processar recomendações');
+    }
+  }
+
+  private async buscarServicosPopulares() {
+    const populares = await this.solicitacaoModel.findAll({
+      attributes: [
+        'servico_id',
+        [fn('COUNT', col('servico_id')), 'quantidade']
+      ],
+      group: ['servico_id'],
+      order: [[literal('quantidade'), 'DESC']],
+      limit: 5,
+      include: [{ model: this.servicoModel, where: { ativo: true } }],
+    });
+
+    return populares.map(p => {
+      const servico = (p as any).servico;
+
+      return {
+        id: servico.id,
+        nome: servico.nome,
+        descricao: servico.descricao,
+      };
+    });
+  }
+
   async buscarAtributosPerfil(usuarioId: number): Promise<PerfilUsuarioDto[]> {
     try {
       this.logger.log(`Buscando serviços do usuário com id ${usuarioId}`);
@@ -30,7 +83,7 @@ export class RecomendacaoService {
         include: [
           {
             model: this.servicoModel,
-            attributes: ['nome', 'descricao', 'valor_base', 'ativo'],
+            attributes: ['id', 'nome', 'descricao', 'valor_base', 'ativo'],
             required: true,
           },
         ],
@@ -44,6 +97,7 @@ export class RecomendacaoService {
       }
 
       return solicitacoes.map((s: SolicitacaoComServicoDto) => ({
+        id: s.servico.id,
         nome: s.servico.nome,
         descricao: s.servico.descricao,
         valor_base: s.servico.valor_base,

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -31,16 +31,16 @@ export class RecomendacaoService {
       const historico = await this.buscarAtributosPerfil(usuarioId);
 
       if (historico.length > 0) {
-        const idsUsados  = historico.map(s => s.id);
-        
+        const idsUsados = historico.map((s) => s.id);
+
         const servicos = await this.servicoModel.findAll({
           where: {
             ativo: true,
-            id: { [Op.notIn]: idsUsados }
-          }
+            id: { [Op.notIn]: idsUsados },
+          },
         });
 
-        return servicos.map(s => ({
+        return servicos.map((s) => ({
           id: s.id,
           nome: s.nome,
           descricao: s.descricao,
@@ -48,27 +48,37 @@ export class RecomendacaoService {
       }
 
       return await this.buscarServicosPopulares();
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erro desconhecido';
 
-    } catch (error) {
-      this.logger.error(`Erro ao gerar recomendações: ${error.message}`);
+      this.logger.error(`Erro ao gerar recomendações: ${errorMessage}`);
       throw new InternalServerErrorException('Erro no processar recomendações');
     }
   }
 
   private async buscarServicosPopulares() {
-    const populares = await this.solicitacaoModel.findAll({
+    const populares = (await this.solicitacaoModel.findAll({
       attributes: [
         'servico_id',
-        [fn('COUNT', col('servico_id')), 'quantidade']
+        [fn('COUNT', col('servico_id')), 'quantidade'],
       ],
       group: ['servico_id'],
       order: [[literal('quantidade'), 'DESC']],
       limit: 5,
-      include: [{ model: this.servicoModel, where: { ativo: true } }],
-    });
+      include: [
+        {
+          model: this.servicoModel,
+          attributes: ['id', 'nome', 'descricao'],
+          where: { ativo: true },
+        },
+      ],
+    })) as unknown as Array<{
+      servico: Pick<Servico, 'id' | 'nome' | 'descricao'>;
+    }>;
 
-    return populares.map(p => {
-      const servico = (p as any).servico;
+    return populares.map((p) => {
+      const servico = p.servico;
 
       return {
         id: servico.id,
@@ -76,6 +86,8 @@ export class RecomendacaoService {
         descricao: servico.descricao,
       };
     });
+  }
+
   async criarInteracao(
     usuarioId: number,
     interacaoDto: RecomendacaoInteracaoRequestDto,


### PR DESCRIPTION
Implementação da rota de recomendações para o catálogo de serviços, o sistema agora sugere serviços com base no histórico do usuário ou, caso não haja histórico, sugere os serviços mais populares.

Criação do Endpoint: GET /recomendacoes/:usuarioId no RecomendacaoController.

Lógica de Recomendação:

Cenário A (Com Histórico): Implementada a filtragem que utiliza o perfil do usuário para excluir serviços já contratados da lista de sugestões (Serviços Ativos - Serviços Contratados).

Cenário B (Sem Histórico): Implementado o fallback que sugere os 5 serviços mais frequentes na tabela de solicitações (popularidade via COUNT).

Testes: Adicionados testes unitários no recomendacao.controller.spec.ts para validar ambos os cenários.

Documentação: Configuração do Swagger para o novo endpoint.

Extensão dos atributos retornados por buscarAtributosPerfil: adição do id para suporte à lógica de filtragem de recomendações, permitindo a diferenciação entre serviços ativos e já contratados pelo usuário.

closes #116