### PR TITLE
feat: Implementa o endpoint DELETE /usuario/:id

### DIFF
--- a/src/models/usuario.model.ts
+++ b/src/models/usuario.model.ts
@@ -1,6 +1,18 @@
-import { Column, DataType, Model, Table } from 'sequelize-typescript';
+import {
+  Column,
+  DataType,
+  DeletedAt,
+  Model,
+  Table,
+} from 'sequelize-typescript';
 
-@Table({ tableName: 'usuario' })
+@Table({
+  tableName: 'usuario',
+  paranoid: true,
+  createdAt: false,
+  updatedAt: false,
+  deletedAt: 'deleted_at',
+})
 export class Usuario extends Model {
   @Column({ primaryKey: true, autoIncrement: true, allowNull: false })
   declare id: number;
@@ -32,4 +44,7 @@ export class Usuario extends Model {
     defaultValue: DataType.NOW,
   })
   declare dataCadastro: Date;
+
+  @DeletedAt
+  declare deletedAt: Date | null;
 }

--- a/src/models/usuario.model.ts
+++ b/src/models/usuario.model.ts
@@ -1,17 +1,9 @@
-import {
-  Column,
-  DataType,
-  DeletedAt,
-  Model,
-  Table,
-} from 'sequelize-typescript';
+import { Column, DataType, Model, Table } from 'sequelize-typescript';
 
 @Table({
   tableName: 'usuario',
-  paranoid: true,
   createdAt: false,
   updatedAt: false,
-  deletedAt: 'deleted_at',
 })
 export class Usuario extends Model {
   @Column({ primaryKey: true, autoIncrement: true, allowNull: false })
@@ -44,7 +36,4 @@ export class Usuario extends Model {
     defaultValue: DataType.NOW,
   })
   declare dataCadastro: Date;
-
-  @DeletedAt
-  declare deletedAt: Date | null;
 }

--- a/src/modules/usuario/usuario.controller.spec.ts
+++ b/src/modules/usuario/usuario.controller.spec.ts
@@ -37,7 +37,7 @@ describe('UsuarioController', () => {
 
   describe('remove', () => {
     it('deve chamar o service com o id correto e retornar mensagem', async () => {
-      const resposta = { mensagem: 'Usuário removido com sucesso!' };
+      const resposta = { message: 'Usuário removido com sucesso!' };
       mockUsuarioService.remove.mockResolvedValue(resposta);
 
       const result = await controller.remove(1);

--- a/src/modules/usuario/usuario.controller.spec.ts
+++ b/src/modules/usuario/usuario.controller.spec.ts
@@ -5,6 +5,7 @@ import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
 
 const mockUsuarioService = {
+  remove: jest.fn(),
   update: jest.fn(),
 };
 
@@ -32,6 +33,30 @@ describe('UsuarioController', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('remove', () => {
+    it('deve chamar o service com o id correto e retornar mensagem', async () => {
+      const resposta = { mensagem: 'Usuário removido com sucesso!' };
+      mockUsuarioService.remove.mockResolvedValue(resposta);
+
+      const result = await controller.remove(1);
+
+      expect(mockUsuarioService.remove).toHaveBeenCalledWith(1);
+      expect(result).toEqual(resposta);
+    });
+
+    it('deve propagar NotFoundException quando service lançar', async () => {
+      mockUsuarioService.remove.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.remove(99)).rejects.toThrow(NotFoundException);
+    });
+
+    it('deve propagar ForbiddenException quando guard lançar', async () => {
+      mockUsuarioService.remove.mockRejectedValue(new ForbiddenException());
+
+      await expect(controller.remove(1)).rejects.toThrow(ForbiddenException);
+    });
   });
 
   describe('update', () => {

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Delete,
   Patch,
   Param,
   Body,
@@ -13,6 +14,12 @@ import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
 @Controller('usuario')
 export class UsuarioController {
   constructor(private readonly usuarioService: UsuarioService) {}
+
+  @Delete(':id')
+  @UseGuards(UsuarioOwnerGuard)
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.usuarioService.remove(id);
+  }
 
   @Patch(':id')
   @UseGuards(UsuarioOwnerGuard)

--- a/src/modules/usuario/usuario.service.spec.ts
+++ b/src/modules/usuario/usuario.service.spec.ts
@@ -18,6 +18,8 @@ const mockUsuario = {
   cpfCnpj: null,
   celular: null,
   dataCadastro: new Date(),
+  deletedAt: null,
+  destroy: jest.fn(),
   update: jest.fn(),
   get: jest.fn().mockReturnValue({
     id: 1,
@@ -28,6 +30,7 @@ const mockUsuario = {
     cpfCnpj: null,
     celular: null,
     dataCadastro: new Date(),
+    deletedAt: null,
   }),
 };
 
@@ -55,6 +58,28 @@ describe('UsuarioService', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('remove', () => {
+    it('deve realizar soft delete preenchendo deletedAt', async () => {
+      mockUsuarioModel.findByPk.mockResolvedValue(mockUsuario);
+      mockUsuario.destroy.mockImplementation(() => {
+        mockUsuario.deletedAt = new Date();
+      });
+
+      const result = await service.remove(1);
+
+      expect(mockUsuarioModel.findByPk).toHaveBeenCalledWith(1);
+      expect(mockUsuario.destroy).toHaveBeenCalled();
+      expect(mockUsuario.deletedAt).not.toBeNull();
+      expect(result).toEqual({ mensagem: 'Usuário removido com sucesso!' });
+    });
+
+    it('deve lançar NotFoundException se usuário não existir', async () => {
+      mockUsuarioModel.findByPk.mockResolvedValue(null);
+
+      await expect(service.remove(99)).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('update', () => {

--- a/src/modules/usuario/usuario.service.spec.ts
+++ b/src/modules/usuario/usuario.service.spec.ts
@@ -18,7 +18,6 @@ const mockUsuario = {
   cpfCnpj: null,
   celular: null,
   dataCadastro: new Date(),
-  deletedAt: null,
   destroy: jest.fn(),
   update: jest.fn(),
   get: jest.fn().mockReturnValue({
@@ -30,7 +29,6 @@ const mockUsuario = {
     cpfCnpj: null,
     celular: null,
     dataCadastro: new Date(),
-    deletedAt: null,
   }),
 };
 
@@ -61,18 +59,15 @@ describe('UsuarioService', () => {
   });
 
   describe('remove', () => {
-    it('deve realizar soft delete preenchendo deletedAt', async () => {
+    it('deve remover o usuário do banco e retornar mensagem de sucesso', async () => {
       mockUsuarioModel.findByPk.mockResolvedValue(mockUsuario);
-      mockUsuario.destroy.mockImplementation(() => {
-        mockUsuario.deletedAt = new Date();
-      });
+      mockUsuario.destroy.mockResolvedValue(undefined);
 
       const result = await service.remove(1);
 
       expect(mockUsuarioModel.findByPk).toHaveBeenCalledWith(1);
       expect(mockUsuario.destroy).toHaveBeenCalled();
-      expect(mockUsuario.deletedAt).not.toBeNull();
-      expect(result).toEqual({ mensagem: 'Usuário removido com sucesso!' });
+      expect(result).toEqual({ message: 'Usuário removido com sucesso!' });
     });
 
     it('deve lançar NotFoundException se usuário não existir', async () => {

--- a/src/modules/usuario/usuario.service.ts
+++ b/src/modules/usuario/usuario.service.ts
@@ -17,6 +17,12 @@ export class UsuarioService {
     private readonly usuarioModel: typeof Usuario,
   ) {}
 
+  async remove(id: number): Promise<{ mensagem: string }> {
+    const usuario = await this.findOneOrFail(id);
+    await usuario.destroy();
+    return { mensagem: 'Usuário removido com sucesso!' };
+  }
+
   async update(
     id: number,
     updateUsuarioDto: UpdateUsuarioDto,

--- a/src/modules/usuario/usuario.service.ts
+++ b/src/modules/usuario/usuario.service.ts
@@ -17,10 +17,10 @@ export class UsuarioService {
     private readonly usuarioModel: typeof Usuario,
   ) {}
 
-  async remove(id: number): Promise<{ mensagem: string }> {
+  async remove(id: number): Promise<{ message: string }> {
     const usuario = await this.findOneOrFail(id);
     await usuario.destroy();
-    return { mensagem: 'Usuário removido com sucesso!' };
+    return { message: 'Usuário removido com sucesso!' };
   }
 
   async update(
@@ -48,7 +48,7 @@ export class UsuarioService {
     const usuario = await this.usuarioModel.findByPk(id);
 
     if (!usuario) {
-      throw new NotFoundException(`Usuário com o ID ${id} não encontrado!`);
+      throw new NotFoundException(`Usuário não encontrado!`);
     }
 
     return usuario;


### PR DESCRIPTION
## 📝 Descrição

Este Pull Request adiciona a funcionalidade de remoção de usuário (`delete`) ao módulo `Usuario`, incluindo controller, lógica de serviço e testes abrangentes.

---

## 🎯 Mudanças Principais

### Endpoint implementado
- `DELETE /usuario/:id` — remoção permanente de um usuário por ID

### Funcionalidade de Remoção (`usuario.service.ts` / `usuario.controller.ts`)

| Arquivo | Alteração |
|---|---|
| `usuario.service.ts` | Adicionado método `remove` — deleta por ID, retorna mensagem de sucesso ou lança `NotFoundException` |
| `usuario.controller.ts` | Adicionado endpoint `DELETE /usuario/:id`, protegido pelo `UsuarioOwnerGuard` |
| `usuario.controller.spec.ts` / `usuario.service.spec.ts` | Testes para os casos de sucesso e erro da remoção |

### Melhorias no Model e Tratamento de Erros

| Arquivo | Alteração |
|---|---|
| `usuario.model.ts` | Desabilitadas as colunas automáticas `createdAt` e `updatedAt` do Sequelize |
| `usuario.service.ts` | Mensagem de erro do `findOneOrFail` simplificada para ser mais genérica |

---

Closes #102