### PR TITLE
feat: Adiciona cadastro de usuarios #35

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['eslint.config.mjs', 'test/**', 'dist/**', 'node_modules/**'],
+    ignores: ['eslint.config.mjs', 'test/**', 'dist/**', 'node_modules/**', '**/*.spec.ts',],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,

--- a/src/modules/usuario/dto/create-usuario.dto.ts
+++ b/src/modules/usuario/dto/create-usuario.dto.ts
@@ -5,6 +5,8 @@ import {
   IsOptional,
   MinLength,
   MaxLength,
+  IsNotEmpty,
+  Matches,
 } from 'class-validator';
 import { Expose, Transform } from 'class-transformer';
 
@@ -16,16 +18,19 @@ export enum NivelUsuario {
 export class CreateUsuarioDto {
   @IsString()
   @MaxLength(100)
-  nome: string;
+  @IsNotEmpty()
+  nome!: string;
 
   @IsEmail()
   @MaxLength(100)
-  email: string;
+  @IsNotEmpty()
+  email!: string;
 
   @IsString()
   @MinLength(6, { message: 'A senha deve ter no mínimo 6 caracteres' })
   @MaxLength(255)
-  senha: string;
+  @IsNotEmpty()
+  senha!: string;
 
   @IsOptional()
   @IsEnum(NivelUsuario, { message: 'Nível inválido' })
@@ -44,11 +49,15 @@ export class CreateUsuarioDto {
     { toClassOnly: true },
   )
   @IsString()
-  @MaxLength(20)
+  @Matches(/^(\d{11}|\d{14})$/, {
+    message: 'CPF/CNPJ inválido',
+  })
   cpfCnpj?: string;
 
   @IsOptional()
   @IsString()
-  @MaxLength(20)
+  @Matches(/^\d{10,11}$/, {
+    message: 'Celular inválido',
+  })
   celular?: string;
 }

--- a/src/modules/usuario/dto/response-usuario.dto.ts
+++ b/src/modules/usuario/dto/response-usuario.dto.ts
@@ -3,25 +3,25 @@ import { Usuario } from 'src/models/usuario.model';
 
 export class ResponseUsuarioDto {
   @Expose()
-  id: number;
+  id!: number;
 
   @Expose()
-  nome: string;
+  nome!: string;
 
   @Expose()
-  email: string;
+  email!: string;
 
   @Expose()
-  nivel: string;
+  nivel!: string;
 
   @Expose()
   @Transform(({ obj }: { obj: Usuario }) => obj.cpfCnpj ?? null)
-  cpf_cnpj: string | null;
+  cpf_cnpj!: string | null;
 
   @Expose()
-  celular: string | null;
+  celular!: string | null;
 
   @Expose()
   @Transform(({ obj }: { obj: Usuario }) => obj.dataCadastro)
-  data_cadastro: Date;
+  data_cadastro!: Date;
 }

--- a/src/modules/usuario/usuario.controller.spec.ts
+++ b/src/modules/usuario/usuario.controller.spec.ts
@@ -1,7 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsuarioController } from './usuario.controller';
 import { UsuarioService } from './usuario.service';
-import { NotFoundException, ForbiddenException, ConflictException } from '@nestjs/common';
+import {
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+} from '@nestjs/common';
 import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
 
 const mockUsuarioService = {
@@ -109,7 +113,6 @@ describe('UsuarioController', () => {
       expect(result).toEqual(respostaCompleta);
     });
   });
-
 
   describe('remove', () => {
     it('deve chamar o service com o id correto e retornar mensagem', async () => {

--- a/src/modules/usuario/usuario.controller.spec.ts
+++ b/src/modules/usuario/usuario.controller.spec.ts
@@ -1,10 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsuarioController } from './usuario.controller';
 import { UsuarioService } from './usuario.service';
-import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { NotFoundException, ForbiddenException, ConflictException } from '@nestjs/common';
 import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
 
 const mockUsuarioService = {
+  create: jest.fn(),
   update: jest.fn(),
 };
 
@@ -32,6 +33,80 @@ describe('UsuarioController', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('register', () => {
+    const dtoBase = {
+      nome: 'João Silva',
+      email: 'joao@gmail.com',
+      senha: 'senha123',
+    };
+
+    const respostaMock = {
+      id: 1,
+      nome: 'João Silva',
+      email: 'joao@gmail.com',
+      nivel: 'cliente',
+      cpf_cnpj: null,
+      celular: null,
+      data_cadastro: new Date('2026-03-14'),
+    };
+
+    it('deve chamar o service com o dto correto e retornar o usuário criado', async () => {
+      mockUsuarioService.create.mockResolvedValue(respostaMock);
+
+      const result = await controller.register(dtoBase);
+
+      expect(mockUsuarioService.create).toHaveBeenCalledWith(dtoBase);
+      expect(result).toEqual(respostaMock);
+    });
+
+    it('não deve retornar o campo senha na resposta', async () => {
+      mockUsuarioService.create.mockResolvedValue(respostaMock);
+
+      const result = await controller.register(dtoBase);
+
+      expect(result).not.toHaveProperty('senha');
+    });
+
+    it('deve retornar os campos no formato correto (snake_case)', async () => {
+      mockUsuarioService.create.mockResolvedValue(respostaMock);
+
+      const result = await controller.register(dtoBase);
+
+      expect(result).toHaveProperty('cpf_cnpj');
+      expect(result).toHaveProperty('data_cadastro');
+    });
+
+    it('deve propagar ConflictException quando e-mail já estiver cadastrado', async () => {
+      mockUsuarioService.create.mockRejectedValue(
+        new ConflictException('Esse e-mail já está cadastrado no sistema.'),
+      );
+
+      await expect(controller.register(dtoBase)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('deve retornar o usuário com cpf_cnpj e celular quando informados', async () => {
+      const dtoCompleto = {
+        ...dtoBase,
+        cpf_cnpj: '12345678901',
+        celular: '11999999999',
+      };
+
+      const respostaCompleta = {
+        ...respostaMock,
+        cpf_cnpj: '12345678901',
+        celular: '11999999999',
+      };
+
+      mockUsuarioService.create.mockResolvedValue(respostaCompleta);
+
+      const result = await controller.register(dtoCompleto);
+
+      expect(result).toEqual(respostaCompleta);
+    });
   });
 
   describe('update', () => {

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -12,12 +12,19 @@ import { UsuarioService } from './usuario.service';
 import { UpdateUsuarioDto } from './dto/update-usuario.dto';
 import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
 import { CreateUsuarioDto } from './dto/create-usuario.dto';
+import { ApiBadRequestResponse, ApiConflictResponse, ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+import { ResponseUsuarioDto } from './dto/response-usuario.dto';
 
 @Controller('usuario')
 export class UsuarioController {
   constructor(private readonly usuarioService: UsuarioService) { }
 
   @Post('register')
+  @Post('register')
+  @ApiOperation({ summary: 'Cadastra um novo usuário no sistema' })
+  @ApiCreatedResponse({ description: 'Usuário cadastrado com sucesso', type: ResponseUsuarioDto })
+  @ApiBadRequestResponse({ description: 'Dados inválidos ou campos obrigatórios ausentes' })
+  @ApiConflictResponse({ description: 'E-mail já cadastrado no sistema' })
   register(@Body() createUsuarioDto: CreateUsuarioDto) {
     return this.usuarioService.create(createUsuarioDto);
   }

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -12,18 +12,28 @@ import { UsuarioService } from './usuario.service';
 import { UpdateUsuarioDto } from './dto/update-usuario.dto';
 import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
 import { CreateUsuarioDto } from './dto/create-usuario.dto';
-import { ApiBadRequestResponse, ApiConflictResponse, ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
 import { ResponseUsuarioDto } from './dto/response-usuario.dto';
 
 @Controller('usuario')
 export class UsuarioController {
-  constructor(private readonly usuarioService: UsuarioService) { }
+  constructor(private readonly usuarioService: UsuarioService) {}
 
   @Post('register')
   @Post('register')
   @ApiOperation({ summary: 'Cadastra um novo usuário no sistema' })
-  @ApiCreatedResponse({ description: 'Usuário cadastrado com sucesso', type: ResponseUsuarioDto })
-  @ApiBadRequestResponse({ description: 'Dados inválidos ou campos obrigatórios ausentes' })
+  @ApiCreatedResponse({
+    description: 'Usuário cadastrado com sucesso',
+    type: ResponseUsuarioDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Dados inválidos ou campos obrigatórios ausentes',
+  })
   @ApiConflictResponse({ description: 'E-mail já cadastrado no sistema' })
   register(@Body() createUsuarioDto: CreateUsuarioDto) {
     return this.usuarioService.create(createUsuarioDto);

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -5,14 +5,21 @@ import {
   Body,
   ParseIntPipe,
   UseGuards,
+  Post,
 } from '@nestjs/common';
 import { UsuarioService } from './usuario.service';
 import { UpdateUsuarioDto } from './dto/update-usuario.dto';
 import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
+import { CreateUsuarioDto } from './dto/create-usuario.dto';
 
 @Controller('usuario')
 export class UsuarioController {
-  constructor(private readonly usuarioService: UsuarioService) {}
+  constructor(private readonly usuarioService: UsuarioService) { }
+
+  @Post('register')
+  register(@Body() createUsuarioDto: CreateUsuarioDto) {
+    return this.usuarioService.create(createUsuarioDto);
+  }
 
   @Patch(':id')
   @UseGuards(UsuarioOwnerGuard)

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -25,7 +25,6 @@ export class UsuarioController {
   constructor(private readonly usuarioService: UsuarioService) {}
 
   @Post('register')
-  @Post('register')
   @ApiOperation({ summary: 'Cadastra um novo usuário no sistema' })
   @ApiCreatedResponse({
     description: 'Usuário cadastrado com sucesso',

--- a/src/modules/usuario/usuario.service.spec.ts
+++ b/src/modules/usuario/usuario.service.spec.ts
@@ -2,7 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UsuarioService } from './usuario.service';
 import { getModelToken } from '@nestjs/sequelize';
 import { Usuario } from 'src/models/usuario.model';
-import { NotFoundException, ConflictException, InternalServerErrorException } from '@nestjs/common';
+import {
+  NotFoundException,
+  ConflictException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 
 jest.mock('bcrypt', () => ({
@@ -114,7 +118,6 @@ describe('UsuarioService', () => {
         InternalServerErrorException,
       );
     });
-
   });
 
   describe('remove', () => {

--- a/src/modules/usuario/usuario.service.spec.ts
+++ b/src/modules/usuario/usuario.service.spec.ts
@@ -2,12 +2,23 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UsuarioService } from './usuario.service';
 import { getModelToken } from '@nestjs/sequelize';
 import { Usuario } from 'src/models/usuario.model';
-import { NotFoundException, ConflictException } from '@nestjs/common';
+import { NotFoundException, ConflictException, InternalServerErrorException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 
 jest.mock('bcrypt', () => ({
   hash: jest.fn().mockResolvedValue('hashed_password'),
 }));
+
+const mockUsuarioToJSON = {
+  id: 1,
+  nome: 'Davi Mathais',
+  email: 'davi@example.com',
+  senha: 'hashed_password',
+  nivel: 'cliente',
+  cpfCnpj: null,
+  celular: null,
+  dataCadastro: new Date(),
+};
 
 const mockUsuario = {
   id: 1,
@@ -19,21 +30,14 @@ const mockUsuario = {
   celular: null,
   dataCadastro: new Date(),
   update: jest.fn(),
-  get: jest.fn().mockReturnValue({
-    id: 1,
-    nome: 'Davi Mathais',
-    email: 'davi@example.com',
-    senha: 'hashed_password',
-    nivel: 'cliente',
-    cpfCnpj: null,
-    celular: null,
-    dataCadastro: new Date(),
-  }),
-};
+  get: jest.fn().mockReturnValue(mockUsuarioToJSON),
+  toJSON: jest.fn().mockReturnValue(mockUsuarioToJSON),
+} as any;
 
 const mockUsuarioModel = {
   findByPk: jest.fn(),
   findOne: jest.fn(),
+  create: jest.fn(),
 };
 
 describe('UsuarioService', () => {
@@ -56,6 +60,61 @@ describe('UsuarioService', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
+  describe('create', () => {
+    const dtoBase = {
+      nome: 'Davi Mathais',
+      email: 'davi@example.com',
+      senha: 'senha123',
+    };
+
+    it('deve criar o usuário com sucesso e retornar sem a senha', async () => {
+      mockUsuarioModel.findOne.mockResolvedValue(null);
+      mockUsuarioModel.create.mockResolvedValue(mockUsuario);
+
+      const result = await service.create(dtoBase);
+
+      expect(mockUsuarioModel.findOne).toHaveBeenCalledWith({
+        where: { email: dtoBase.email },
+      });
+      expect(bcrypt.hash).toHaveBeenCalledWith(dtoBase.senha, 10);
+      expect(mockUsuarioModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nome: dtoBase.nome,
+          email: dtoBase.email,
+          senha: 'hashed_password',
+        }),
+      );
+      expect(result).not.toHaveProperty('senha');
+    });
+
+    it('deve retornar os campos no formato correto (snake_case)', async () => {
+      mockUsuarioModel.findOne.mockResolvedValue(null);
+      mockUsuarioModel.create.mockResolvedValue(mockUsuario);
+
+      const result = await service.create(dtoBase);
+
+      expect(result).toHaveProperty('cpf_cnpj');
+      expect(result).toHaveProperty('data_cadastro');
+    });
+
+    it('deve lançar ConflictException se e-mail já estiver cadastrado', async () => {
+      mockUsuarioModel.findOne.mockResolvedValue(mockUsuario);
+
+      await expect(service.create(dtoBase)).rejects.toThrow(ConflictException);
+      expect(mockUsuarioModel.create).not.toHaveBeenCalled();
+    });
+
+    it('deve lançar InternalServerErrorException se o create falhar', async () => {
+      mockUsuarioModel.findOne.mockResolvedValue(null);
+      mockUsuarioModel.create.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.create(dtoBase)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+  });;
 
   describe('update', () => {
     it('deve atualizar o usuário com sucesso', async () => {

--- a/src/modules/usuario/usuario.service.spec.ts
+++ b/src/modules/usuario/usuario.service.spec.ts
@@ -115,7 +115,7 @@ describe('UsuarioService', () => {
       );
     });
 
-  });;
+  });
 
   describe('remove', () => {
     it('deve remover o usuário do banco e retornar mensagem de sucesso', async () => {

--- a/src/modules/usuario/usuario.service.ts
+++ b/src/modules/usuario/usuario.service.ts
@@ -35,7 +35,7 @@ export class UsuarioService {
         nome: dto.nome,
         email: dto.email,
         senha: senhaHash,
-        nivel: dto.nivel ?? 'cliente',
+        nivel: 'cliente',
         cpfCnpj: dto.cpfCnpj ?? null,
         celular: dto.celular ?? null,
       });

--- a/src/modules/usuario/usuario.service.ts
+++ b/src/modules/usuario/usuario.service.ts
@@ -17,7 +17,7 @@ export class UsuarioService {
   constructor(
     @InjectModel(Usuario)
     private readonly usuarioModel: typeof Usuario,
-  ) { }
+  ) {}
 
   async create(dto: CreateUsuarioDto): Promise<ResponseUsuarioDto> {
     const emailExistente = await this.usuarioModel.findOne({
@@ -47,7 +47,6 @@ export class UsuarioService {
       throw new InternalServerErrorException('Erro ao criar usuário');
     }
   }
-
 
   async remove(id: number): Promise<{ message: string }> {
     const usuario = await this.findOneOrFail(id);

--- a/src/modules/usuario/usuario.service.ts
+++ b/src/modules/usuario/usuario.service.ts
@@ -2,11 +2,13 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import * as bcrypt from 'bcrypt';
 import { Usuario } from 'src/models/usuario.model';
 import { UpdateUsuarioDto } from './dto/update-usuario.dto';
+import { CreateUsuarioDto } from './dto/create-usuario.dto';
 import { ResponseUsuarioDto } from './dto/response-usuario.dto';
 import { plainToInstance } from 'class-transformer';
 
@@ -15,7 +17,37 @@ export class UsuarioService {
   constructor(
     @InjectModel(Usuario)
     private readonly usuarioModel: typeof Usuario,
-  ) {}
+  ) { }
+
+  async create(dto: CreateUsuarioDto): Promise<ResponseUsuarioDto> {
+    const emailExistente = await this.usuarioModel.findOne({
+      where: { email: dto.email },
+    });
+
+    if (emailExistente) {
+      throw new ConflictException('Esse e-mail já está cadastrado no sistema.');
+    }
+
+    const senhaHash = await bcrypt.hash(dto.senha, 10);
+
+    try {
+      const usuario = await this.usuarioModel.create({
+        nome: dto.nome,
+        email: dto.email,
+        senha: senhaHash,
+        nivel: dto.nivel ?? 'cliente',
+        cpfCnpj: dto.cpfCnpj ?? null,
+        celular: dto.celular ?? null,
+      });
+
+      return plainToInstance(ResponseUsuarioDto, usuario.toJSON(), {
+        excludeExtraneousValues: true,
+      });
+    } catch {
+      throw new InternalServerErrorException('Erro ao criar usuário');
+    }
+  }
+
 
   async update(
     id: number,


### PR DESCRIPTION
## O que foi feito

- Implementação do fluxo de cadastro de usuários, incluindo validação dos campos obrigatórios, verificação de e-mail único e criptografia da senha utilizando bcrypt.

- Tratamento dos campos opcionais (`cpf_cnpj` e `celular`). Os campos `nivel` e `data_cadastro` são definidos automaticamente pelo banco com seus valores padrão.

- A resposta da API retorna os dados do usuário no formato esperado, sem expor a senha.

- Adicionados testes unitários para garantir o funcionamento do endpoint e cobrir os principais cenários.

closes #35 