### PR TITLE
feat: Adiciona busca avançada por status em publicidade.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2597,7 +2596,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2645,7 +2643,6 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2716,7 +2713,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
       "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2748,7 +2744,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.16.tgz",
       "integrity": "sha512-3fYQTi8F2hb7HDkes/ArGhY8lkjB/Df29F5CN4cjbk4cmfpRVy89p6N1BC7PjVOHMAzdwqeX8FabqspdSAnywA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -2860,7 +2855,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.16.tgz",
       "integrity": "sha512-kfLhCFsq6139JVFCQpbFB6LOEjZzdpE7JzXsZtRbVjqmsgTKVSIh8gKRgzpcq27rbLNqHhhZavboOltOfSxZow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3158,7 +3152,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3305,7 +3298,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3403,8 +3395,7 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -3468,7 +3459,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4176,7 +4166,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4226,7 +4215,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4655,7 +4643,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4907,15 +4894,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5695,7 +5680,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5756,7 +5740,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7044,7 +7027,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8968,7 +8950,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9138,8 +9119,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9242,7 +9222,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9341,7 +9320,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -9407,7 +9385,6 @@
       "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-2.1.6.tgz",
       "integrity": "sha512-Vc2N++3en346RsbGjL3h7tgAl2Y7V+2liYTAOZ8XL0KTw3ahFHsyAUzOwct51n+g70I1TOUDgs06Oh6+XGcFkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "7.2.0"
       },
@@ -10102,7 +10079,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10423,7 +10399,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10571,7 +10546,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10838,7 +10812,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10908,7 +10881,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Logger, Query } from '@nestjs/common';
 import { BuscaService } from './busca.service';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
+import { BuscaPublicidadeStatusDto } from './dto/busca-publicidade-status.dto';
 import { Blog } from 'src/models/blog.model';
 import { ApiOperation } from '@nestjs/swagger';
 
@@ -31,6 +32,16 @@ export class BuscaController {
     this.logger.log(`Buscando banners por status: status=${dto.status}`);
     return this.buscaService.buscarBannerPorStatus(dto);
   }
+
+  @Get('publicidade/status')
+  @ApiOperation({
+    summary: "Buscar publicidades com base em status: 'ativo' e 'inativo'",
+  })
+  buscarPublicidadePorStatus(@Query() dto: BuscaPublicidadeStatusDto) {
+    this.logger.log(`Buscando publicidades por status: status=${dto.status}`);
+    return this.buscaService.buscarPublicidadePorStatus(dto);
+  }
+
   @Get('blog/termo')
   @ApiOperation({
     summary:

--- a/src/modules/busca/busca.module.ts
+++ b/src/modules/busca/busca.module.ts
@@ -4,9 +4,10 @@ import { BuscaController } from './busca.controller';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { Blog } from 'src/models/blog.model';
 import { Banner } from 'src/models/banner.model';
+import { Publicidade } from 'src/models/publicidade.model';
 
 @Module({
-  imports: [SequelizeModule.forFeature([Blog, Banner])],
+  imports: [SequelizeModule.forFeature([Blog, Banner, Publicidade])],
   controllers: [BuscaController],
   providers: [BuscaService],
 })

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -5,13 +5,14 @@ import { BuscaService } from './busca.service';
 import { BadRequestException } from '@nestjs/common';
 import { Blog } from 'src/models/blog.model';
 import { Banner } from 'src/models/banner.model';
+import { Publicidade } from 'src/models/publicidade.model';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
 
 describe('BuscaService', () => {
   let service: BuscaService;
   const blogFindAllMock = jest.fn();
   const bannerFindAllMock = jest.fn();
-
+  const publicidadeFindAllMock = jest.fn();
   type WhereClause = Partial<Record<symbol, unknown>>;
 
   interface FindAllOptions {
@@ -22,6 +23,7 @@ describe('BuscaService', () => {
   beforeEach(async () => {
     blogFindAllMock.mockReset();
     bannerFindAllMock.mockReset();
+    publicidadeFindAllMock.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -36,6 +38,12 @@ describe('BuscaService', () => {
           provide: getModelToken(Banner),
           useValue: {
             findAll: bannerFindAllMock,
+          },
+        },
+        {
+          provide: getModelToken(Publicidade),
+          useValue: {
+            findAll: publicidadeFindAllMock,
           },
         },
       ],
@@ -174,6 +182,38 @@ describe('BuscaService', () => {
 
     expect(bannerFindAllMock).toHaveBeenCalledTimes(1);
     expect(bannerFindAllMock).toHaveBeenCalledWith({
+      where: {
+        ativo: false,
+      },
+    });
+  });
+
+  it('deve buscar publicidades ativas quando status=ativo', async () => {
+    const retorno = [{ id: 1 }];
+    publicidadeFindAllMock.mockResolvedValue(retorno);
+
+    await expect(
+      service.buscarPublicidadePorStatus({ status: 'ativo' }),
+    ).resolves.toEqual(retorno);
+
+    expect(publicidadeFindAllMock).toHaveBeenCalledTimes(1);
+    expect(publicidadeFindAllMock).toHaveBeenCalledWith({
+      where: {
+        ativo: true,
+      },
+    });
+  });
+
+  it('deve buscar publicidades inativas quando status=inativo', async () => {
+    const retorno = [{ id: 1 }];
+    publicidadeFindAllMock.mockResolvedValue(retorno);
+
+    await expect(
+      service.buscarPublicidadePorStatus({ status: 'inativo' }),
+    ).resolves.toEqual(retorno);
+
+    expect(publicidadeFindAllMock).toHaveBeenCalledTimes(1);
+    expect(publicidadeFindAllMock).toHaveBeenCalledWith({
       where: {
         ativo: false,
       },

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -3,14 +3,16 @@ import { InjectModel } from '@nestjs/sequelize';
 import { col, Op, where } from 'sequelize';
 import { Banner } from 'src/models/banner.model';
 import { Blog } from 'src/models/blog.model';
+import { Publicidade } from 'src/models/publicidade.model';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
-
+import { BuscaPublicidadeStatusDto } from './dto/busca-publicidade-status.dto';
 @Injectable()
 export class BuscaService {
   constructor(
     @InjectModel(Blog) private blogModel: typeof Blog,
     @InjectModel(Banner) private bannerModel: typeof Banner,
+    @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
   ) {}
 
   async buscarBlogsPorIntervaloDeData(
@@ -49,6 +51,17 @@ export class BuscaService {
   async buscarBannerPorStatus(dto: BuscaBannerStatusDto): Promise<Banner[]> {
     const ativo = dto.status === 'ativo';
     return await this.bannerModel.findAll({
+      where: {
+        ativo,
+      },
+    });
+  }
+
+  async buscarPublicidadePorStatus(
+    dto: BuscaPublicidadeStatusDto,
+  ): Promise<Publicidade[]> {
+    const ativo = dto.status === 'ativo';
+    return await this.publicidadeModel.findAll({
       where: {
         ativo,
       },

--- a/src/modules/busca/dto/busca-banner-status.dto.ts
+++ b/src/modules/busca/dto/busca-banner-status.dto.ts
@@ -1,5 +1,6 @@
 import { Transform, type TransformFnParams } from 'class-transformer';
 import { IsIn, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class BuscaBannerStatusDto {
   @Transform(({ value }: TransformFnParams) =>
@@ -8,6 +9,11 @@ export class BuscaBannerStatusDto {
   @IsString()
   @IsIn(['ativo', 'inativo'], {
     message: 'Campo "status" deve ser "ativo" ou "inativo"',
+  })
+  @ApiPropertyOptional({
+    description: 'Status do banner',
+    example: 'ativo',
+    type: String,
   })
   declare status: 'ativo' | 'inativo';
 }

--- a/src/modules/busca/dto/busca-publicidade-status.dto.ts
+++ b/src/modules/busca/dto/busca-publicidade-status.dto.ts
@@ -1,5 +1,6 @@
 import { Transform, type TransformFnParams } from 'class-transformer';
 import { IsIn, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class BuscaPublicidadeStatusDto {
   @Transform(({ value }: TransformFnParams) =>
@@ -8,6 +9,11 @@ export class BuscaPublicidadeStatusDto {
   @IsString()
   @IsIn(['ativo', 'inativo'], {
     message: 'Campo "status" deve ser "ativo" ou "inativo"',
+  })
+  @ApiPropertyOptional({
+    description: 'Status da publicidade',
+    example: 'ativo',
+    type: String,
   })
   declare status: 'ativo' | 'inativo';
 }

--- a/src/modules/busca/dto/busca-publicidade-status.dto.ts
+++ b/src/modules/busca/dto/busca-publicidade-status.dto.ts
@@ -1,0 +1,13 @@
+import { Transform, type TransformFnParams } from 'class-transformer';
+import { IsIn, IsString } from 'class-validator';
+
+export class BuscaPublicidadeStatusDto {
+  @Transform(({ value }: TransformFnParams) =>
+    typeof value === 'string' ? value.trim().toLowerCase() : (value as unknown),
+  )
+  @IsString()
+  @IsIn(['ativo', 'inativo'], {
+    message: 'Campo "status" deve ser "ativo" ou "inativo"',
+  })
+  declare status: 'ativo' | 'inativo';
+}


### PR DESCRIPTION
## O que foi feito

- Adiciona o endpoint `GET /busca/publicidade/status` para retornar publicidades filtradas por status (ativo ou inativo).
- Inclui validação do parâmetro `status`:
  - normaliza a entrada (`trim()` + `toLowerCase()`),
  - valida valores permitidos (`ativo` | `inativo`).
- Implementa a busca no serviço convertendo `status` em filtro booleano `ativo` na consulta ao banco.
- Adiciona/atualiza testes unitários garantindo o comportamento para:
  - `status=ativo` → `ativo: true`
  - `status=inativo` → `ativo: false`
- Já com os sumários do swagger no controller e no dto, da parte de publicidade status
---

## Como testar

- Buscar publicidades ativas:
  - `GET /busca/publicidade/status?status=ativo`
  - Retorna apenas publicidades com `ativo=true`.

- Buscar publicidades inativas:
  - `GET /busca/publicidade/status?status=inativo`
  - Retorna apenas publicidades com `ativo=false`.

closes #174 