### PR TITLE
feat: Adiciona busca avançada de serviços, com filtros.

### DIFF
--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -2,7 +2,9 @@ import { Controller, Get, Logger, Query } from '@nestjs/common';
 import { BuscaService } from './busca.service';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
+import { BuscaServicoFiltroDto } from './dto/busca-servico-filtro.dto';
 import { Blog } from 'src/models/blog.model';
+import { Servico } from 'src/models/servico.model';
 import { ApiOperation } from '@nestjs/swagger';
 
 @Controller('busca')
@@ -53,5 +55,21 @@ export class BuscaController {
       `Listando itens do carrossel com filtro: ${termo ?? 'sem filtro'}`,
     );
     return this.buscaService.listarBannersByTermo(termo);
+  }
+
+  @Get('servico/filtros')
+  @ApiOperation({
+    summary:
+      'Buscar serviços por filtros (valor base, prazo estimado e status)',
+    description:
+      'Parâmetros opcionais: valor_base (decimal), prazo_estimado (inteiro em dias) e status (ativo|inativo).',
+  })
+  buscarServicosPorFiltros(
+    @Query() dto: BuscaServicoFiltroDto,
+  ): Promise<Servico[]> {
+    this.logger.log(
+      `Buscando servicos por filtros: valor_base=${dto.valor_base ?? 'n/a'} prazo_estimado=${dto.prazo_estimado ?? 'n/a'} status=${dto.status ?? 'n/a'}`,
+    );
+    return this.buscaService.buscarServicosPorFiltros(dto);
   }
 }

--- a/src/modules/busca/busca.module.ts
+++ b/src/modules/busca/busca.module.ts
@@ -4,9 +4,10 @@ import { BuscaController } from './busca.controller';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { Blog } from 'src/models/blog.model';
 import { Banner } from 'src/models/banner.model';
+import { Servico } from 'src/models/servico.model';
 
 @Module({
-  imports: [SequelizeModule.forFeature([Blog, Banner])],
+  imports: [SequelizeModule.forFeature([Blog, Banner, Servico])],
   controllers: [BuscaController],
   providers: [BuscaService],
 })

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -49,7 +49,7 @@ describe('BuscaService', () => {
           provide: getModelToken(Servico),
           useValue: {
             findAll: servicoFindAllMock,
-          }
+          },
         },
         {
           provide: getModelToken(Publicidade),

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -321,13 +321,13 @@ describe('BuscaService', () => {
   });
 
   describe('buscarServicosPorFiltros', () => {
-    it('deve listar servicos sem filtros ordenando por id decrescente', async () => {
+    it('deve listar servicos sem filtros ordenando por id crescente', async () => {
       servicoFindAllMock.mockResolvedValue([]);
 
       await service.buscarServicosPorFiltros({});
 
       expect(servicoFindAllMock).toHaveBeenCalledWith({
-        order: [['id', 'DESC']],
+        order: [['id', 'ASC']],
       });
     });
 
@@ -346,7 +346,7 @@ describe('BuscaService', () => {
       expect(args.where).toBeDefined();
       const whereClause = args.where as WhereClause;
       expect(whereClause[Op.and]).toHaveLength(1);
-      expect(args.order).toEqual([['id', 'DESC']]);
+      expect(args.order).toEqual([['id', 'ASC']]);
     });
 
     it('deve filtrar por prazo_estimado quando informado', async () => {

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -5,12 +5,15 @@ import { BuscaService } from './busca.service';
 import { BadRequestException } from '@nestjs/common';
 import { Blog } from 'src/models/blog.model';
 import { Banner } from 'src/models/banner.model';
+import { Servico } from 'src/models/servico.model';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
+import { BuscaServicoFiltroDto } from './dto/busca-servico-filtro.dto';
 
 describe('BuscaService', () => {
   let service: BuscaService;
   const blogFindAllMock = jest.fn();
   const bannerFindAllMock = jest.fn();
+  const servicoFindAllMock = jest.fn();
 
   type WhereClause = Partial<Record<symbol, unknown>>;
 
@@ -22,6 +25,7 @@ describe('BuscaService', () => {
   beforeEach(async () => {
     blogFindAllMock.mockReset();
     bannerFindAllMock.mockReset();
+    servicoFindAllMock.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -36,6 +40,12 @@ describe('BuscaService', () => {
           provide: getModelToken(Banner),
           useValue: {
             findAll: bannerFindAllMock,
+          },
+        },
+        {
+          provide: getModelToken(Servico),
+          useValue: {
+            findAll: servicoFindAllMock,
           },
         },
       ],
@@ -307,6 +317,86 @@ describe('BuscaService', () => {
         },
         order: [['id', 'DESC']],
       });
+    });
+  });
+
+  describe('buscarServicosPorFiltros', () => {
+    it('deve listar servicos sem filtros ordenando por id decrescente', async () => {
+      servicoFindAllMock.mockResolvedValue([]);
+
+      await service.buscarServicosPorFiltros({});
+
+      expect(servicoFindAllMock).toHaveBeenCalledWith({
+        order: [['id', 'DESC']],
+      });
+    });
+
+    it('deve filtrar por valor_base quando informado', async () => {
+      servicoFindAllMock.mockResolvedValue([]);
+
+      await service.buscarServicosPorFiltros({
+        valor_base: 180,
+      } as unknown as BuscaServicoFiltroDto);
+
+      expect(servicoFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = servicoFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      expect(args.where).toBeDefined();
+      const whereClause = args.where as WhereClause;
+      expect(whereClause[Op.and]).toHaveLength(1);
+      expect(args.order).toEqual([['id', 'DESC']]);
+    });
+
+    it('deve filtrar por prazo_estimado quando informado', async () => {
+      servicoFindAllMock.mockResolvedValue([]);
+
+      await service.buscarServicosPorFiltros({
+        prazo_estimado: 5,
+      } as unknown as BuscaServicoFiltroDto);
+
+      expect(servicoFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = servicoFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      const whereClause = args.where as WhereClause;
+      expect(whereClause[Op.and]).toHaveLength(1);
+    });
+
+    it('deve filtrar por status quando informado', async () => {
+      servicoFindAllMock.mockResolvedValue([]);
+
+      await service.buscarServicosPorFiltros({
+        status: 'inativo',
+      } as unknown as BuscaServicoFiltroDto);
+
+      expect(servicoFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = servicoFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      const whereClause = args.where as WhereClause;
+      expect(whereClause[Op.and]).toHaveLength(1);
+    });
+
+    it('deve combinar filtros quando mais de um campo é informado', async () => {
+      servicoFindAllMock.mockResolvedValue([]);
+
+      await service.buscarServicosPorFiltros({
+        valor_base: 350,
+        prazo_estimado: 5,
+        status: 'ativo',
+      } as unknown as BuscaServicoFiltroDto);
+
+      expect(servicoFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = servicoFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      const whereClause = args.where as WhereClause;
+      expect(whereClause[Op.and]).toHaveLength(3);
     });
   });
 });

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -16,7 +16,7 @@ export class BuscaService {
     @InjectModel(Banner) private bannerModel: typeof Banner,
     @InjectModel(Servico) private servicoModel: typeof Servico,
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
-  ) { }
+  ) {}
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -65,13 +65,14 @@ export class BuscaService {
     ];
 
     if (filtros.length === 0) {
-      return await this.servicoModel.findAll();
+      return await this.servicoModel.findAll({ order: [['id', 'ASC']] });
     }
 
     return await this.servicoModel.findAll({
       where: {
         [Op.and]: filtros,
       },
+      order: [['id', 'ASC']],
     });
   }
 

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -3,14 +3,17 @@ import { InjectModel } from '@nestjs/sequelize';
 import { col, Op, where } from 'sequelize';
 import { Banner } from 'src/models/banner.model';
 import { Blog } from 'src/models/blog.model';
+import { Servico } from 'src/models/servico.model';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
+import { BuscaServicoFiltroDto } from './dto/busca-servico-filtro.dto';
 
 @Injectable()
 export class BuscaService {
   constructor(
     @InjectModel(Blog) private blogModel: typeof Blog,
     @InjectModel(Banner) private bannerModel: typeof Banner,
+    @InjectModel(Servico) private servicoModel: typeof Servico,
   ) {}
 
   async buscarBlogsPorIntervaloDeData(
@@ -40,6 +43,32 @@ export class BuscaService {
     ];
 
     return await this.blogModel.findAll({
+      where: {
+        [Op.and]: filtros,
+      },
+    });
+  }
+
+  async buscarServicosPorFiltros(
+    dto: BuscaServicoFiltroDto,
+  ): Promise<Servico[]> {
+    const filtros = [
+      ...(dto.valor_base !== undefined
+        ? [where(col('valor_base'), Op.eq, dto.valor_base)]
+        : []),
+      ...(dto.prazo_estimado !== undefined
+        ? [where(col('prazo_estimado_dias'), Op.eq, dto.prazo_estimado)]
+        : []),
+      ...(dto.status
+        ? [where(col('ativo'), Op.eq, dto.status === 'ativo')]
+        : []),
+    ];
+
+    if (filtros.length === 0) {
+      return await this.servicoModel.findAll();
+    }
+
+    return await this.servicoModel.findAll({
       where: {
         [Op.and]: filtros,
       },

--- a/src/modules/busca/dto/busca-servico-filtro.dto.ts
+++ b/src/modules/busca/dto/busca-servico-filtro.dto.ts
@@ -1,0 +1,47 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type, type TransformFnParams } from 'class-transformer';
+import { IsIn, IsInt, IsNumber, IsOptional, Min } from 'class-validator';
+
+export class BuscaServicoFiltroDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber(
+    { maxDecimalPlaces: 2 },
+    {
+      message:
+        'Campo "valor_base" deve ser uma quantia real, tipo double, exemplo: 98.00',
+    },
+  )
+  @Min(0, { message: 'Campo "valor_base" deve ser maior ou igual a 0' })
+  @ApiPropertyOptional({
+    description: 'Valor base do serviço (decimal, 2 casas)',
+    example: 145.0,
+    type: Number,
+  })
+  declare valor_base?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt({ message: 'Campo "prazo_estimado" deve ser um inteiro' })
+  @Min(0, { message: 'Campo "prazo_estimado" deve ser maior ou igual a 0' })
+  @ApiPropertyOptional({
+    description: 'Prazo estimado para execução do serviço, em dias',
+    example: 15,
+    type: Number,
+  })
+  declare prazo_estimado?: number;
+
+  @IsOptional()
+  @Transform(({ value }: TransformFnParams) =>
+    typeof value === 'string' ? value.trim().toLowerCase() : (value as unknown),
+  )
+  @IsIn(['ativo', 'inativo'], {
+    message: 'Campo "status" deve ser "ativo" ou "inativo"',
+  })
+  @ApiPropertyOptional({
+    description: 'Status do serviço',
+    example: 'ativo',
+    enum: ['ativo', 'inativo'],
+  })
+  declare status?: 'ativo' | 'inativo';
+}


### PR DESCRIPTION
## O que foi feito

- Este PR adiciona uma funcionalidade de busca avançada de serviços no módulo de busca, permitindo filtrar registros por:
  - Valor Base (`valor_base`)
  - Prazo Estimado (dias) (`prazo_estimado_dias`, via query `prazo_estimado`)
  - Status (`ativo` / `inativo`)

- Principais mudanças:
  - Criação/ajuste do DTO de filtros para serviços, com validações e transformação de tipos (número decimal, inteiro e enum de status).
  - Implementação da lógica de filtros no `BuscaService`, montando a cláusula `where` via Sequelize (`Op.and` + `where(col(...))`), seguindo o padrão já existente no módulo.
  - Exposição de novo endpoint no `BuscaController` para consulta via query params.
  - Atualização do `BuscaModule` para incluir o model `Servico` no `SequelizeModule.forFeature`.
  - Adição de testes unitários cobrindo cenários:
    - sem filtros (lista ordenada por `id ASC`)
    - filtros individuais (`valor_base`, `prazo_estimado`, `status`)
    - combinação de filtros (3 campos)

---

## Como testar

- Endpoint:
  - `GET /busca/servico/filtros`

- Query params (opcionais):
  - `valor_base` (decimal, ex: `180.00`)
  - `prazo_estimado` (int, ex: `5`)
  - `status` (`ativo` | `inativo`)
  
  closes #176 