### PR TITLE
feat(busca-avancada): adicionar filtro de usuários por nível e data de cadastro

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -236,6 +236,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2596,6 +2597,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
       "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.2",
         "iterare": "1.2.1",
@@ -2643,6 +2645,7 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2713,6 +2716,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
       "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -2744,6 +2748,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.16.tgz",
       "integrity": "sha512-3fYQTi8F2hb7HDkes/ArGhY8lkjB/Df29F5CN4cjbk4cmfpRVy89p6N1BC7PjVOHMAzdwqeX8FabqspdSAnywA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -2855,6 +2860,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.16.tgz",
       "integrity": "sha512-kfLhCFsq6139JVFCQpbFB6LOEjZzdpE7JzXsZtRbVjqmsgTKVSIh8gKRgzpcq27rbLNqHhhZavboOltOfSxZow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3152,6 +3158,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3298,6 +3305,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3395,7 +3403,8 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -3459,6 +3468,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4166,6 +4176,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4215,6 +4226,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4643,6 +4655,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4894,13 +4907,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.4",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
       "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -5680,6 +5695,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5740,6 +5756,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7027,6 +7044,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8950,6 +8968,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9119,7 +9138,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -9222,6 +9242,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9320,6 +9341,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/validator": "^13.7.17",
@@ -9385,6 +9407,7 @@
       "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-2.1.6.tgz",
       "integrity": "sha512-Vc2N++3en346RsbGjL3h7tgAl2Y7V+2liYTAOZ8XL0KTw3ahFHsyAUzOwct51n+g70I1TOUDgs06Oh6+XGcFkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob": "7.2.0"
       },
@@ -10079,6 +10102,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10399,6 +10423,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10546,6 +10571,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10812,6 +10838,7 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -10881,6 +10908,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -3,7 +3,9 @@ import { BuscaService } from './busca.service';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
 import { BuscaPublicidadeStatusDto } from './dto/busca-publicidade-status.dto';
+import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
 import { Blog } from 'src/models/blog.model';
+import { Usuario } from 'src/models/usuario.model';
 import { ApiOperation } from '@nestjs/swagger';
 
 @Controller('busca')
@@ -22,6 +24,22 @@ export class BuscaController {
       `Buscando blogs por intervalo de data: de=${dto.de} ate=${dto.ate}`,
     );
     return this.buscaService.buscarBlogsPorIntervaloDeData(dto);
+  }
+
+  @Get('usuario/filtros')
+  @ApiOperation({
+    summary:
+      'Buscar usuários por filtros (nível de usuário e data de cadastro)',
+    description:
+      'Parâmetros opcionais: nivel_usuario ("cliente" ou "administrador") e data_cadastro (data no formato YYYY-MM-DD).',
+  })
+  buscarUsuariosPorFiltros(
+    @Query() dto: BuscaUsuarioFiltroDto,
+  ): Promise<Usuario[]> {
+    this.logger.log(
+      `Buscando usuarios por filtros: nivel_usuario=${dto.nivel_usuario ?? 'n/a'} data_cadastro=${dto.data_cadastro ?? 'n/a'}`,
+    );
+    return this.buscaService.buscarUsuariosPorFiltros(dto);
   }
 
   @Get('banner/status')

--- a/src/modules/busca/busca.module.ts
+++ b/src/modules/busca/busca.module.ts
@@ -9,7 +9,9 @@ import { Publicidade } from 'src/models/publicidade.model';
 import { Usuario } from 'src/models/usuario.model';
 
 @Module({
-  imports: [SequelizeModule.forFeature([Blog, Banner, Publicidade, Servico, Usuario])],
+  imports: [
+    SequelizeModule.forFeature([Blog, Banner, Publicidade, Servico, Usuario]),
+  ],
   controllers: [BuscaController],
   providers: [BuscaService],
 })

--- a/src/modules/busca/busca.module.ts
+++ b/src/modules/busca/busca.module.ts
@@ -5,9 +5,10 @@ import { SequelizeModule } from '@nestjs/sequelize';
 import { Blog } from 'src/models/blog.model';
 import { Banner } from 'src/models/banner.model';
 import { Publicidade } from 'src/models/publicidade.model';
+import { Usuario } from 'src/models/usuario.model';
 
 @Module({
-  imports: [SequelizeModule.forFeature([Blog, Banner, Publicidade])],
+  imports: [SequelizeModule.forFeature([Blog, Banner, Publicidade, Usuario])],
   controllers: [BuscaController],
   providers: [BuscaService],
 })

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -6,13 +6,16 @@ import { BadRequestException } from '@nestjs/common';
 import { Blog } from 'src/models/blog.model';
 import { Banner } from 'src/models/banner.model';
 import { Publicidade } from 'src/models/publicidade.model';
+import { Usuario } from 'src/models/usuario.model';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
+import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
 
 describe('BuscaService', () => {
   let service: BuscaService;
   const blogFindAllMock = jest.fn();
   const bannerFindAllMock = jest.fn();
   const publicidadeFindAllMock = jest.fn();
+  const usuarioFindAllMock = jest.fn();
   type WhereClause = Partial<Record<symbol, unknown>>;
 
   interface FindAllOptions {
@@ -24,7 +27,7 @@ describe('BuscaService', () => {
     blogFindAllMock.mockReset();
     bannerFindAllMock.mockReset();
     publicidadeFindAllMock.mockReset();
-
+    usuarioFindAllMock.mockReset();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BuscaService,
@@ -44,6 +47,12 @@ describe('BuscaService', () => {
           provide: getModelToken(Publicidade),
           useValue: {
             findAll: publicidadeFindAllMock,
+          },
+        },
+        {
+          provide: getModelToken(Usuario),
+          useValue: {
+            findAll: usuarioFindAllMock,
           },
         },
       ],
@@ -305,6 +314,68 @@ describe('BuscaService', () => {
         },
         order: [['id', 'DESC']],
       });
+    });
+  });
+
+  describe('buscarUsuariosPorFiltros', () => {
+    it('deve listar servicos sem filtros ordenando por id crescente', async () => {
+      usuarioFindAllMock.mockResolvedValue([]);
+      await service.buscarUsuariosPorFiltros({});
+
+      expect(usuarioFindAllMock).toHaveBeenCalledWith({
+        order: [['id', 'ASC']],
+      });
+    });
+
+    it('deve filtrar por nivel_usuario quando informado', async () => {
+      usuarioFindAllMock.mockResolvedValue([]);
+
+      await service.buscarUsuariosPorFiltros({
+        nivel_usuario: 'cliente',
+      } as unknown as BuscaUsuarioFiltroDto);
+
+      expect(usuarioFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = usuarioFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      expect(args.where).toBeDefined();
+      const whereClause = args.where as WhereClause;
+      expect(whereClause[Op.and]).toHaveLength(1);
+      expect(args.order).toEqual([['id', 'ASC']]);
+    });
+
+    it('deve filtrar por data_cadastro quando informado', async () => {
+      usuarioFindAllMock.mockResolvedValue([]);
+
+      await service.buscarUsuariosPorFiltros({
+        data_cadastro: '2026-03-03',
+      } as unknown as BuscaUsuarioFiltroDto);
+
+      expect(usuarioFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = usuarioFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      const whereClause = args.where as WhereClause;
+      expect(whereClause[Op.and]).toHaveLength(1);
+    });
+
+    it('deve combinar filtros quando mais de um campo é informado', async () => {
+      usuarioFindAllMock.mockResolvedValue([]);
+
+      await service.buscarUsuariosPorFiltros({
+        nivel_usuario: 'administrador',
+        data_cadastro: '2026-04-11',
+      } as unknown as BuscaUsuarioFiltroDto);
+
+      expect(usuarioFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = usuarioFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      const whereClause = args.where as WhereClause;
+      expect(whereClause[Op.and]).toHaveLength(2);
     });
   });
 

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -329,7 +329,7 @@ describe('BuscaService', () => {
   });
 
   describe('buscarUsuariosPorFiltros', () => {
-    it('deve listar servicos sem filtros ordenando por id crescente', async () => {
+    it('deve listar usuarios sem filtros ordenando por id crescente', async () => {
       usuarioFindAllMock.mockResolvedValue([]);
       await service.buscarUsuariosPorFiltros({});
 

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -1,18 +1,22 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
-import { col, Op, where } from 'sequelize';
+import { col, fn, Op, where } from 'sequelize';
 import { Banner } from 'src/models/banner.model';
 import { Blog } from 'src/models/blog.model';
 import { Publicidade } from 'src/models/publicidade.model';
+import { Usuario } from 'src/models/usuario.model';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
 import { BuscaPublicidadeStatusDto } from './dto/busca-publicidade-status.dto';
+import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
+
 @Injectable()
 export class BuscaService {
   constructor(
     @InjectModel(Blog) private blogModel: typeof Blog,
     @InjectModel(Banner) private bannerModel: typeof Banner,
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
+    @InjectModel(Usuario) private usuarioModel: typeof Usuario,
   ) {}
 
   async buscarBlogsPorIntervaloDeData(
@@ -45,6 +49,35 @@ export class BuscaService {
       where: {
         [Op.and]: filtros,
       },
+    });
+  }
+
+  async buscarUsuariosPorFiltros(
+    dto: BuscaUsuarioFiltroDto,
+  ): Promise<Usuario[]> {
+    const nivelUsuario = dto.nivel_usuario?.toLowerCase() as
+      | 'cliente'
+      | 'administrador'
+      | undefined;
+
+    const filtros = [
+      ...(nivelUsuario !== undefined
+        ? [where(col('nivel'), Op.eq, nivelUsuario)]
+        : []),
+      ...(dto.data_cadastro !== undefined
+        ? [where(fn('DATE', col('data_cadastro')), Op.eq, dto.data_cadastro)]
+        : []),
+    ];
+
+    if (filtros.length === 0) {
+      return await this.usuarioModel.findAll({ order: [['id', 'ASC']] });
+    }
+
+    return await this.usuarioModel.findAll({
+      where: {
+        [Op.and]: filtros,
+      },
+      order: [['id', 'ASC']],
     });
   }
 

--- a/src/modules/busca/dto/busca-usuario-filtro.dto.ts
+++ b/src/modules/busca/dto/busca-usuario-filtro.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsString, Matches, IsDateString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class BuscaUsuarioFiltroDto {
+  @IsOptional()
+  @IsString()
+  @IsDateString(
+    {},
+    {
+      message:
+        'Campo "data_cadastro" deve ser data válida no formato YYYY-MM-DD',
+    },
+  )
+  @ApiPropertyOptional({
+    description: 'Data de cadastro do usuário para filtrar os resultados',
+    example: '2025-10-29',
+    type: String,
+  })
+  declare data_cadastro?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^(cliente|administrador)$/i, {
+    message:
+      'Campo "nivel_usuario" deve ser um nível de usuário válido, "cliente" ou "administrador"',
+  })
+  @ApiPropertyOptional({
+    description: 'Nível do usuário para filtrar os resultados',
+    example: 'cliente',
+    type: String,
+  })
+  declare nivel_usuario?: 'cliente' | 'administrador';
+}

--- a/src/modules/busca/dto/busca-usuario-filtro.dto.ts
+++ b/src/modules/busca/dto/busca-usuario-filtro.dto.ts
@@ -1,4 +1,10 @@
-import { IsOptional, IsString, Matches, IsDateString, IsIn } from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  Matches,
+  IsDateString,
+  IsIn,
+} from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class BuscaUsuarioFiltroDto {
@@ -20,14 +26,15 @@ export class BuscaUsuarioFiltroDto {
 
   @IsOptional()
   @IsString()
-  @IsIn(['cliente', 'administrador', 'Cliente', 'Administrador'], {  // ou transforme antes
+  @IsIn(['cliente', 'administrador', 'Cliente', 'Administrador'], {
+    // ou transforme antes
     message:
       'Campo "nivel_usuario" deve ser um nível de usuário válido, "cliente" ou "administrador"',
   })
   @ApiPropertyOptional({
     description: 'Nível do usuário para filtrar os resultados',
     example: 'cliente',
-    enum: ['cliente', 'administrador']
+    enum: ['cliente', 'administrador'],
   })
   declare nivel_usuario?: 'cliente' | 'administrador';
 }

--- a/src/modules/busca/dto/busca-usuario-filtro.dto.ts
+++ b/src/modules/busca/dto/busca-usuario-filtro.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, Matches, IsDateString } from 'class-validator';
+import { IsOptional, IsString, Matches, IsDateString, IsIn } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class BuscaUsuarioFiltroDto {
@@ -20,14 +20,14 @@ export class BuscaUsuarioFiltroDto {
 
   @IsOptional()
   @IsString()
-  @Matches(/^(cliente|administrador)$/i, {
+  @IsIn(['cliente', 'administrador', 'Cliente', 'Administrador'], {  // ou transforme antes
     message:
       'Campo "nivel_usuario" deve ser um nível de usuário válido, "cliente" ou "administrador"',
   })
   @ApiPropertyOptional({
     description: 'Nível do usuário para filtrar os resultados',
     example: 'cliente',
-    type: String,
+    enum: ['cliente', 'administrador']
   })
   declare nivel_usuario?: 'cliente' | 'administrador';
 }


### PR DESCRIPTION
## O que foi feito

Adiciona funcionalidade de filtro de usuários por nível de acesso (cliente/administrador) e data de cadastro no módulo de busca.

## O que foi feito

- Novo endpoint `GET /busca/usuario/filtros` para buscar usuários com filtros opcionais
- Suporte a filtro por `nivel_usuario` (cliente ou administrador)
- Suporte a filtro por `data_cadastro` (formato YYYY-MM-DD)
- Comparação de data usando `DATE()` do MySQL para datetime fields
- Normalização de valores de entrada (minúsculas)
- Testes unitários completos para todos os cenários de filtro
- Documentação via Swagger

## Detalhes técnicos

- Criado DTO `BuscaUsuarioFiltroDto` com validação de formato de data e enum de nível
- Método `buscarUsuariosPorFiltros` implementado no serviço
- Atualizado módulo para injetar dependência do modelo `Usuario`
- Filtros combinados com operador `Op.and` do Sequelize

## Como testar

```bash
# Filtro por nível
GET /busca/usuario/filtros?nivel_usuario=cliente

# Filtro por data
GET /busca/usuario/filtros?data_cadastro=2026-03-03

# Filtro combinado
GET /busca/usuario/filtros?nivel_usuario=administrador&data_cadastro=2026-03-03

closes #177 