### PR TITLE
feat: Implementa busca simples de servicos por termo

### DIFF
--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -116,4 +116,17 @@ export class BuscaController {
     );
     return this.buscaService.listarUsuariosByTermo(termo);
   }
+
+  @Get('servico/termo')
+  @ApiOperation({
+    summary:
+      'Buscar serviços por termo simples nos campos nome, descrição, valor base e prazo estimado',
+  })
+  listarServicos(@Query('termo') termo?: string): Promise<{
+    itens: Servico[];
+    mensagem?: string;
+  }> {
+    this.logger.log(`Listando servicos com filtro: ${termo ?? 'sem filtro'}`);
+    return this.buscaService.listarServicosByTermo(termo);
+  }
 }

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -292,6 +292,58 @@ export class BuscaService {
     };
   }
 
+  async listarServicosByTermo(termo?: string): Promise<{
+    itens: Servico[];
+    mensagem?: string;
+  }> {
+    const termoNormalizado = termo?.trim();
+
+    if (!termoNormalizado) {
+      const itens = await this.servicoModel.findAll({
+        order: [['id', 'DESC']],
+      });
+
+      return {
+        itens,
+        mensagem:
+          itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
+      };
+    }
+
+    const filtros: Array<Record<string, unknown> | ReturnType<typeof where>> = [
+      { nome: { [Op.like]: `%${termoNormalizado}%` } },
+      { descricao: { [Op.like]: `%${termoNormalizado}%` } },
+    ];
+
+    const termoEhNumero = /^(0|[1-9]\d*)(\.\d+)?$/.test(termoNormalizado);
+    if (termoEhNumero) {
+      const termoComoNumero = Number(termoNormalizado);
+      if (!Number.isNaN(termoComoNumero)) {
+        filtros.push(where(col('valor_base'), Op.eq, termoComoNumero));
+      }
+    }
+
+    const termoEhInteiroDecimal = /^(0|[1-9]\d*)$/.test(termoNormalizado);
+    if (termoEhInteiroDecimal) {
+      const termoComoInteiro = parseInt(termoNormalizado, 10);
+      if (!Number.isNaN(termoComoInteiro)) {
+        filtros.push(
+          where(col('prazo_estimado_dias'), Op.eq, termoComoInteiro),
+        );
+      }
+    }
+
+    const itens = await this.servicoModel.findAll({
+      where: { [Op.or]: filtros },
+      order: [['id', 'DESC']],
+    });
+
+    return {
+      itens,
+      mensagem: itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
+    };
+  }
+
   private normalizarDataBusca(valor: string): string | undefined {
     const valorYmd = valor.match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (valorYmd) {


### PR DESCRIPTION
## Implementação da busca de serviços

- Criação do endpoint `GET /busca/servico/termo` no módulo de busca.
- Inclusão de documentação Swagger para o endpoint, descrevendo que a busca simples considera:
  - nome  
  - descrição  
  - valor base  
  - prazo estimado  

- Adição de log no controller para registrar quando a listagem é feita com termo ou sem filtro.

### Regra de busca no service
- Normalização do termo com `trim`.
- Quando o termo não é informado, retorna todos os serviços ordenados por `id` decrescente.
- Quando o termo é texto, aplica busca parcial com `LIKE` em `nome` e `descrição`.
- Quando o termo é número decimal, também compara igualdade em `valor_base`.
- Quando o termo é número inteiro, também compara igualdade em `prazo_estimado_dias`.

### Outros ajustes
- Retorno padronizado com itens e mensagem `"Nenhum item foi encontrado."` quando não houver resultados.
- Atualização do `package-lock.json` decorrente de alterações no ambiente/dependências.
- Ajustes de formatação nos construtores (controller/service) no mesmo commit.

Closes #178