### PR TITLE
175 correto feature implementação da busca simples para o cms de publicidade

### DIFF
--- a/src/modules/busca/busca.controller.spec.ts
+++ b/src/modules/busca/busca.controller.spec.ts
@@ -7,12 +7,14 @@ describe('BuscaController', () => {
   const buscaServiceMock = {
     listarBlogByTermo: jest.fn(),
     listarBannersByTermo: jest.fn(),
+    listarPublicidadeByTermo: jest.fn(),
     listarUsuariosByTermo: jest.fn(),
   };
 
   beforeEach(async () => {
     buscaServiceMock.listarBlogByTermo.mockReset();
     buscaServiceMock.listarBannersByTermo.mockReset();
+    buscaServiceMock.listarPublicidadeByTermo.mockReset();
     buscaServiceMock.listarUsuariosByTermo.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -54,5 +56,15 @@ describe('BuscaController', () => {
     await controller.listarUsuarios('joao');
 
     expect(buscaServiceMock.listarUsuariosByTermo).toHaveBeenCalledWith('joao');
+  });
+
+  it('deve delegar a listagem de publicidade para o BuscaService', async () => {
+    buscaServiceMock.listarPublicidadeByTermo.mockResolvedValue({ itens: [] });
+
+    await controller.listarPublicidade('promo');
+
+    expect(buscaServiceMock.listarPublicidadeByTermo).toHaveBeenCalledWith(
+      'promo',
+    );
   });
 });

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Logger, Query } from '@nestjs/common';
 import { ApiOperation } from '@nestjs/swagger';
 import { Blog } from 'src/models/blog.model';
+import { Publicidade } from 'src/models/publicidade.model';
 import { Servico } from 'src/models/servico.model';
 import { Usuario } from 'src/models/usuario.model';
 import { BuscaService } from './busca.service';
@@ -13,7 +14,7 @@ import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
 @Controller('busca')
 export class BuscaController {
   private readonly logger = new Logger(BuscaController.name);
-  constructor(private readonly buscaService: BuscaService) {}
+  constructor(private readonly buscaService: BuscaService) { }
 
   @Get('blog/periodo')
   @ApiOperation({
@@ -84,6 +85,20 @@ export class BuscaController {
       `Listando itens do carrossel com filtro: ${termo ?? 'sem filtro'}`,
     );
     return this.buscaService.listarBannersByTermo(termo);
+  }
+
+  @Get('publicidade/termo')
+  @ApiOperation({
+    summary: 'Buscar publicidades por termo presente em imagem, conteúdo ou id',
+  })
+  listarPublicidade(@Query('termo') termo?: string): Promise<{
+    itens: Publicidade[];
+    mensagem?: string;
+  }> {
+    this.logger.log(
+      `Listando publicidades do CMS com filtro: ${termo?.trim() ?? 'sem filtro'}`,
+    );
+    return this.buscaService.listarPublicidadeByTermo(termo);
   }
 
   @Get('servico/filtros')

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -14,7 +14,7 @@ import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
 @Controller('busca')
 export class BuscaController {
   private readonly logger = new Logger(BuscaController.name);
-  constructor(private readonly buscaService: BuscaService) { }
+  constructor(private readonly buscaService: BuscaService) {}
 
   @Get('blog/periodo')
   @ApiOperation({

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -478,7 +478,9 @@ describe('BuscaService', () => {
     });
 
     it('deve aplicar fallback para filtro textual quando termo numerico nao encontrar id exato', async () => {
-      publicidadeFindAllMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      publicidadeFindAllMock
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
 
       await service.listarPublicidadeByTermo('12');
 

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -434,6 +434,81 @@ describe('BuscaService', () => {
     });
   });
 
+  describe('listarPublicidadeByTermo', () => {
+    it('deve retornar mensagem quando nao encontrar itens sem filtro', async () => {
+      publicidadeFindAllMock.mockResolvedValue([]);
+
+      const resultado = await service.listarPublicidadeByTermo();
+
+      expect(publicidadeFindAllMock).toHaveBeenCalledWith({
+        order: [['id', 'DESC']],
+      });
+      expect(resultado).toEqual({
+        itens: [],
+        mensagem: 'Nenhum item foi encontrado.',
+      });
+    });
+
+    it('deve montar filtro por imagem e conteudo quando termo textual for informado', async () => {
+      publicidadeFindAllMock.mockResolvedValue([]);
+
+      await service.listarPublicidadeByTermo('  campanha  ');
+
+      expect(publicidadeFindAllMock).toHaveBeenCalledWith({
+        where: {
+          [Op.or]: [
+            { urlImagem: { [Op.like]: '%campanha%' } },
+            { conteudo: { [Op.like]: '%campanha%' } },
+          ],
+        },
+        order: [['id', 'DESC']],
+      });
+    });
+
+    it('deve buscar apenas por id quando termo numerico encontrar registro com id exato', async () => {
+      publicidadeFindAllMock.mockResolvedValue([{ id: 12 }]);
+
+      await service.listarPublicidadeByTermo('12');
+
+      expect(publicidadeFindAllMock).toHaveBeenCalledWith({
+        where: { id: 12 },
+        order: [['id', 'DESC']],
+      });
+      expect(publicidadeFindAllMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('deve aplicar fallback para filtro textual quando termo numerico nao encontrar id exato', async () => {
+      publicidadeFindAllMock.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await service.listarPublicidadeByTermo('12');
+
+      expect(publicidadeFindAllMock).toHaveBeenNthCalledWith(1, {
+        where: { id: 12 },
+        order: [['id', 'DESC']],
+      });
+      expect(publicidadeFindAllMock).toHaveBeenNthCalledWith(2, {
+        where: {
+          [Op.or]: [
+            { urlImagem: { [Op.like]: '%12%' } },
+            { conteudo: { [Op.like]: '%12%' } },
+          ],
+        },
+        order: [['id', 'DESC']],
+      });
+    });
+
+    it('deve buscar apenas por id quando termo estiver no formato id N', async () => {
+      publicidadeFindAllMock.mockResolvedValue([]);
+
+      await service.listarPublicidadeByTermo('id 9');
+
+      expect(publicidadeFindAllMock).toHaveBeenCalledWith({
+        where: { id: 9 },
+        order: [['id', 'DESC']],
+      });
+    });
+  });
+
   describe('buscarServicosPorFiltros', () => {
     it('deve listar servicos sem filtros ordenando por id crescente', async () => {
       servicoFindAllMock.mockResolvedValue([]);

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -20,7 +20,7 @@ export class BuscaService {
     @InjectModel(Servico) private servicoModel: typeof Servico,
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
-  ) { }
+  ) {}
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,
@@ -278,9 +278,7 @@ export class BuscaService {
         return {
           itens: itensPorId,
           mensagem:
-            itensPorId.length === 0
-              ? 'Nenhum item foi encontrado.'
-              : undefined,
+            itensPorId.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
         };
       }
     }

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -20,7 +20,7 @@ export class BuscaService {
     @InjectModel(Servico) private servicoModel: typeof Servico,
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
-  ) {}
+  ) { }
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,
@@ -245,6 +245,78 @@ export class BuscaService {
       itens,
       mensagem: itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
     };
+  }
+
+  async listarPublicidadeByTermo(termo?: string): Promise<{
+    itens: Publicidade[];
+    mensagem?: string;
+  }> {
+    const termoNormalizado = termo?.trim();
+
+    if (!termoNormalizado) {
+      const itens = await this.publicidadeModel.findAll({
+        order: [['id', 'DESC']],
+      });
+
+      return {
+        itens,
+        mensagem:
+          itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
+      };
+    }
+
+    const idExtraido = this.extrairIdExato(termoNormalizado);
+    const buscaIdExplicita = this.termoRepresentaIdExplicito(termoNormalizado);
+
+    if (idExtraido !== undefined) {
+      const itensPorId = await this.publicidadeModel.findAll({
+        where: { id: idExtraido },
+        order: [['id', 'DESC']],
+      });
+
+      if (itensPorId.length > 0 || buscaIdExplicita) {
+        return {
+          itens: itensPorId,
+          mensagem:
+            itensPorId.length === 0
+              ? 'Nenhum item foi encontrado.'
+              : undefined,
+        };
+      }
+    }
+
+    const filtros: Array<Record<string, unknown>> = [
+      { urlImagem: { [Op.like]: `%${termoNormalizado}%` } },
+      { conteudo: { [Op.like]: `%${termoNormalizado}%` } },
+    ];
+
+    const itens = await this.publicidadeModel.findAll({
+      where: { [Op.or]: filtros },
+      order: [['id', 'DESC']],
+    });
+
+    return {
+      itens,
+      mensagem: itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
+    };
+  }
+
+  private extrairIdExato(valor: string): number | undefined {
+    const valorNumerico = valor.match(/^(0|[1-9]\d*)$/);
+    if (valorNumerico) {
+      return parseInt(valorNumerico[1], 10);
+    }
+
+    const valorComPrefixoId = valor.match(/^id\s*[:#-]?\s*(0|[1-9]\d*)$/i);
+    if (valorComPrefixoId) {
+      return parseInt(valorComPrefixoId[1], 10);
+    }
+
+    return undefined;
+  }
+
+  private termoRepresentaIdExplicito(valor: string): boolean {
+    return /^id\s*[:#-]?\s*(0|[1-9]\d*)$/i.test(valor);
   }
 
   async listarUsuariosByTermo(termo?: string): Promise<{


### PR DESCRIPTION
Foi criado um novo endpoint para busca de publicidades por termo, incluindo regras de interpretação do termo e cobertura de testes.

---

## Controller

Arquivo: `busca.controller.ts`

### Nova rota
- GET /busca/publicidade/termo

### Query Params
- termo (opcional)

### Comportamento
- Delega a busca para o service
- Registra log com o filtro aplicado
- Retorna:
  - Lista de publicidades
  - Mensagem opcional quando não há resultados

---

## Service

Arquivo: `busca.service.ts`

### Novo método
- listarPublicidadeByTermo(termo?)

### Regras de busca

- Sem termo
  - Retorna todas as publicidades ordenadas por id DESC

- Termo numérico (ex: 12)
  - Tenta busca exata por id

- Formato explícito de id
  - Exemplos: id 9, id:9, id-9
  - Força busca exata por id
  - Não aplica fallback textual

- Fallback (quando aplicável)
  - Caso termo numérico não encontre resultado
  - Aplica busca textual

- Busca textual
  - OR LIKE nos campos:
    - urlImagem
    - conteudo

- Sem resultados
  - Retorna mensagem padrão:
    Nenhum item foi encontrado.

---

## Métodos auxiliares

### extrairIdExato
- Interpreta:
  - Número puro válido
  - Formatos com prefixo id

### termoRepresentaIdExplicito
- Detecta se o termo está explicitamente no formato de ID
- Usado para evitar fallback indevido

---

## Testes

### Service

Arquivo: `busca.service.spec.ts`

Coberturas:
- Sem filtro e sem resultados
- Busca textual por campos de publicidade
- Busca por ID numérico com retorno encontrado
- Fallback textual quando ID não encontra resultado
- Busca por formato explícito de ID sem fallback indevido

---

### Controller

Arquivo: `busca.controller.spec.ts`

- Valida que:
  - listarPublicidade chama listarPublicidadeByTermo com o termo correto

---

## Resultado

- Endpoint flexível para diferentes tipos de busca
- Tratamento inteligente de termos numéricos e textuais
- Cobertura de testes garantindo confiabilidade

Closes #175