### PR TITLE
feat(busca): adicionar busca e filtros dinâmicos de empresa

### DIFF
--- a/src/models/empresa.model.ts
+++ b/src/models/empresa.model.ts
@@ -32,4 +32,16 @@ export class Empresa extends Model {
 
   @Column({ type: DataType.STRING(100), allowNull: true })
   declare site: string | null;
+
+  @Column({
+    type: DataType.ENUM('clinica', 'vistoria', 'detran'),
+    allowNull: true,
+  })
+  declare tipo: 'clinica' | 'vistoria' | 'detran' | null;
+
+  @Column({ type: DataType.STRING(20), allowNull: true })
+  declare latitude: string | null;
+
+  @Column({ type: DataType.STRING(20), allowNull: true })
+  declare longitude: string | null;
 }

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -1,11 +1,13 @@
 import { Controller, Get, Logger, Query } from '@nestjs/common';
 import { ApiOperation } from '@nestjs/swagger';
 import { Blog } from 'src/models/blog.model';
+import { Empresa } from 'src/models/empresa.model';
 import { Servico } from 'src/models/servico.model';
 import { Usuario } from 'src/models/usuario.model';
 import { BuscaService } from './busca.service';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
+import { BuscaEmpresaFiltroDto } from './dto/busca-empresa-filtro.dto';
 import { BuscaPublicidadeStatusDto } from './dto/busca-publicidade-status.dto';
 import { BuscaServicoFiltroDto } from './dto/busca-servico-filtro.dto';
 import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
@@ -100,6 +102,45 @@ export class BuscaController {
       `Buscando servicos por filtros: valor_base=${dto.valor_base ?? 'n/a'} prazo_estimado=${dto.prazo_estimado ?? 'n/a'} status=${dto.status ?? 'n/a'}`,
     );
     return this.buscaService.buscarServicosPorFiltros(dto);
+  }
+
+  @Get('empresa/filtros')
+  @ApiOperation({
+    summary: 'Buscar empresas por filtros (tipo, estado e cidade)',
+    description:
+      'Parâmetros opcionais: tipo (clinica|detran|vistoria), estado (UF) e cidade (string).',
+  })
+  buscarEmpresasPorFiltros(
+    @Query() dto: BuscaEmpresaFiltroDto,
+  ): Promise<Empresa[]> {
+    this.logger.log(
+      `Buscando empresas por filtros: tipo=${dto.tipo ?? 'n/a'} estado=${dto.estado ?? 'n/a'} cidade=${dto.cidade ?? 'n/a'}`,
+    );
+    return this.buscaService.buscarEmpresasPorFiltros(dto);
+  }
+
+  @Get('empresa/estados')
+  @ApiOperation({
+    summary: 'Listar UFs (estados) disponíveis nas empresas',
+    description:
+      'Retorna apenas UFs únicas encontradas na tabela empresa (para preencher o filtro de estado).',
+  })
+  listarEstadosEmpresas(): Promise<string[]> {
+    this.logger.log('Listando estados disponíveis nas empresas');
+    return this.buscaService.listarEstadosEmpresas();
+  }
+
+  @Get('empresa/cidades')
+  @ApiOperation({
+    summary: 'Listar cidades disponíveis nas empresas (opcionalmente por UF)',
+    description:
+      'Sem UF retorna todas as cidades únicas; com UF retorna somente as cidades das empresas daquele estado.',
+  })
+  listarCidadesEmpresas(@Query('estado') estado?: string): Promise<string[]> {
+    this.logger.log(
+      `Listando cidades disponíveis nas empresas: estado=${estado?.trim() ?? 'n/a'}`,
+    );
+    return this.buscaService.listarCidadesEmpresas(estado);
   }
 
   @Get('usuario/termo')

--- a/src/modules/busca/busca.module.ts
+++ b/src/modules/busca/busca.module.ts
@@ -7,10 +7,18 @@ import { Banner } from 'src/models/banner.model';
 import { Servico } from 'src/models/servico.model';
 import { Publicidade } from 'src/models/publicidade.model';
 import { Usuario } from 'src/models/usuario.model';
+import { Empresa } from 'src/models/empresa.model';
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([Blog, Banner, Publicidade, Servico, Usuario]),
+    SequelizeModule.forFeature([
+      Blog,
+      Banner,
+      Publicidade,
+      Servico,
+      Usuario,
+      Empresa,
+    ]),
   ],
   controllers: [BuscaController],
   providers: [BuscaService],

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -38,7 +38,6 @@ describe('BuscaService', () => {
     servicoFindAllMock.mockReset();
     publicidadeFindAllMock.mockReset();
     usuarioFindAllMock.mockReset();
-    usuarioFindAllMock.mockReset();
     empresaFindAllMock.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -8,6 +8,7 @@ import { Banner } from 'src/models/banner.model';
 import { Servico } from 'src/models/servico.model';
 import { Publicidade } from 'src/models/publicidade.model';
 import { Usuario } from 'src/models/usuario.model';
+import { Empresa } from 'src/models/empresa.model';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
 import { BuscaServicoFiltroDto } from './dto/busca-servico-filtro.dto';
 import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
@@ -19,11 +20,16 @@ describe('BuscaService', () => {
   const servicoFindAllMock = jest.fn();
   const usuarioFindAllMock = jest.fn();
   const publicidadeFindAllMock = jest.fn();
+  const empresaFindAllMock = jest.fn();
   type WhereClause = Partial<Record<symbol, unknown>>;
 
   interface FindAllOptions {
     where?: unknown;
     order?: unknown;
+    attributes?: unknown;
+    group?: unknown;
+    raw?: unknown;
+    [key: string]: unknown;
   }
 
   beforeEach(async () => {
@@ -33,6 +39,7 @@ describe('BuscaService', () => {
     publicidadeFindAllMock.mockReset();
     usuarioFindAllMock.mockReset();
     usuarioFindAllMock.mockReset();
+    empresaFindAllMock.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -67,6 +74,12 @@ describe('BuscaService', () => {
             findAll: usuarioFindAllMock,
           },
         },
+        {
+          provide: getModelToken(Empresa),
+          useValue: {
+            findAll: empresaFindAllMock,
+          },
+        },
       ],
     }).compile();
 
@@ -75,6 +88,133 @@ describe('BuscaService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('buscarEmpresasPorFiltros', () => {
+    it('deve listar empresas sem filtros ordenando por id crescente', async () => {
+      const retorno = [{ id: 1 }];
+      empresaFindAllMock.mockResolvedValue(retorno);
+
+      await expect(service.buscarEmpresasPorFiltros({})).resolves.toEqual(
+        retorno,
+      );
+
+      expect(empresaFindAllMock).toHaveBeenCalledTimes(1);
+      expect(empresaFindAllMock).toHaveBeenCalledWith({
+        order: [['id', 'ASC']],
+      });
+    });
+
+    it('deve filtrar por tipo quando informado', async () => {
+      const retorno = [{ id: 1 }];
+      empresaFindAllMock.mockResolvedValue(retorno);
+
+      await expect(
+        service.buscarEmpresasPorFiltros({ tipo: 'detran' }),
+      ).resolves.toEqual(retorno);
+
+      expect(empresaFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = empresaFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      const whereClause = (args.where as WhereClause) ?? {};
+      expect(whereClause[Op.and]).toHaveLength(1);
+      expect(args.order).toEqual([['id', 'ASC']]);
+    });
+
+    it('deve combinar filtros quando mais de um campo é informado', async () => {
+      const retorno = [{ id: 1 }];
+      empresaFindAllMock.mockResolvedValue(retorno);
+
+      await expect(
+        service.buscarEmpresasPorFiltros({
+          tipo: 'clinica',
+          estado: 'PR',
+          cidade: 'Curitiba',
+        }),
+      ).resolves.toEqual(retorno);
+
+      expect(empresaFindAllMock).toHaveBeenCalledTimes(1);
+      const calls = empresaFindAllMock.mock.calls as Array<
+        Array<FindAllOptions>
+      >;
+      const args = calls[0]?.[0];
+      const whereClause = (args.where as WhereClause) ?? {};
+      expect(whereClause[Op.and]).toHaveLength(3);
+      expect(args.order).toEqual([['id', 'ASC']]);
+    });
+  });
+
+  describe('listarEstadosEmpresas', () => {
+    it('deve retornar apenas UFs únicas, sem nulos/vazios', async () => {
+      empresaFindAllMock.mockResolvedValue([
+        { estado: 'PR' },
+        { estado: 'SP' },
+        { estado: 'PR' },
+        { estado: null },
+        { estado: '  ' },
+      ]);
+
+      await expect(service.listarEstadosEmpresas()).resolves.toEqual([
+        'PR',
+        'SP',
+      ]);
+
+      expect(empresaFindAllMock).toHaveBeenCalledTimes(1);
+      expect(empresaFindAllMock).toHaveBeenCalledWith({
+        attributes: ['estado'],
+        group: ['estado'],
+        order: [['estado', 'ASC']],
+        raw: true,
+      });
+    });
+  });
+
+  describe('listarCidadesEmpresas', () => {
+    it('sem estado deve retornar todas as cidades únicas', async () => {
+      empresaFindAllMock.mockResolvedValue([
+        { cidade: 'Curitiba' },
+        { cidade: 'Maringá' },
+        { cidade: 'Curitiba' },
+        { cidade: null },
+        { cidade: '   ' },
+      ]);
+
+      await expect(service.listarCidadesEmpresas()).resolves.toEqual([
+        'Curitiba',
+        'Maringá',
+      ]);
+
+      expect(empresaFindAllMock).toHaveBeenCalledTimes(1);
+      expect(empresaFindAllMock).toHaveBeenCalledWith({
+        attributes: ['cidade'],
+        group: ['cidade'],
+        order: [['cidade', 'ASC']],
+        raw: true,
+      });
+    });
+
+    it('com estado deve filtrar cidades do estado informado (UF normalizada)', async () => {
+      empresaFindAllMock.mockResolvedValue([
+        { cidade: 'Curitiba' },
+        { cidade: 'Londrina' },
+      ]);
+
+      await expect(service.listarCidadesEmpresas(' pr ')).resolves.toEqual([
+        'Curitiba',
+        'Londrina',
+      ]);
+
+      expect(empresaFindAllMock).toHaveBeenCalledTimes(1);
+      expect(empresaFindAllMock).toHaveBeenCalledWith({
+        attributes: ['cidade'],
+        where: { estado: 'PR' },
+        group: ['cidade'],
+        order: [['cidade', 'ASC']],
+        raw: true,
+      });
+    });
   });
 
   it('deve buscar blogs entre datas (incluindo limites)', async () => {

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -3,11 +3,13 @@ import { InjectModel } from '@nestjs/sequelize';
 import { col, fn, Op, where } from 'sequelize';
 import { Banner } from 'src/models/banner.model';
 import { Blog } from 'src/models/blog.model';
+import { Empresa } from 'src/models/empresa.model';
 import { Publicidade } from 'src/models/publicidade.model';
 import { Servico } from 'src/models/servico.model';
 import { Usuario } from 'src/models/usuario.model';
 import { BuscaBannerStatusDto } from './dto/busca-banner-status.dto';
 import { BuscaBlogIntervaloDto } from './dto/busca-blog-intervalo.dto';
+import { BuscaEmpresaFiltroDto } from './dto/busca-empresa-filtro.dto';
 import { BuscaPublicidadeStatusDto } from './dto/busca-publicidade-status.dto';
 import { BuscaServicoFiltroDto } from './dto/busca-servico-filtro.dto';
 import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
@@ -20,6 +22,7 @@ export class BuscaService {
     @InjectModel(Servico) private servicoModel: typeof Servico,
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
+    @InjectModel(Empresa) private empresaModel: typeof Empresa,
   ) {}
 
   async buscarBlogsPorIntervaloDeData(
@@ -133,6 +136,62 @@ export class BuscaService {
         ativo,
       },
     });
+  }
+
+  async buscarEmpresasPorFiltros(
+    dto: BuscaEmpresaFiltroDto,
+  ): Promise<Empresa[]> {
+    const filtros = [
+      ...(dto.tipo ? [where(col('tipo'), Op.eq, dto.tipo)] : []),
+      ...(dto.estado ? [where(col('estado'), Op.eq, dto.estado)] : []),
+      ...(dto.cidade ? [where(col('cidade'), Op.eq, dto.cidade)] : []),
+    ];
+
+    if (filtros.length === 0) {
+      return await this.empresaModel.findAll({ order: [['id', 'ASC']] });
+    }
+
+    return await this.empresaModel.findAll({
+      where: {
+        [Op.and]: filtros,
+      },
+      order: [['id', 'ASC']],
+    });
+  }
+
+  async listarEstadosEmpresas(): Promise<string[]> {
+    const rows = (await this.empresaModel.findAll({
+      attributes: ['estado'],
+      group: ['estado'],
+      order: [['estado', 'ASC']],
+      raw: true,
+    })) as Array<{ estado?: string | null }>;
+
+    const valores = rows
+      .map((r) => (r.estado ?? '').trim())
+      .filter((v) => v.length > 0);
+
+    return Array.from(new Set(valores));
+  }
+
+  async listarCidadesEmpresas(estado?: string): Promise<string[]> {
+    const estadoNormalizado = estado?.trim() ? estado.trim().toUpperCase() : '';
+
+    const rows = (await this.empresaModel.findAll({
+      attributes: ['cidade'],
+      ...(estadoNormalizado
+        ? { where: { estado: estadoNormalizado } }
+        : undefined),
+      group: ['cidade'],
+      order: [['cidade', 'ASC']],
+      raw: true,
+    })) as Array<{ cidade?: string | null }>;
+
+    const valores = rows
+      .map((r) => (r.cidade ?? '').trim())
+      .filter((v) => v.length > 0);
+
+    return Array.from(new Set(valores));
   }
 
   private parseYmdDate(

--- a/src/modules/busca/dto/busca-empresa-filtro.dto.ts
+++ b/src/modules/busca/dto/busca-empresa-filtro.dto.ts
@@ -1,0 +1,61 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, type TransformFnParams } from 'class-transformer';
+import { IsIn, IsOptional, IsString, Matches } from 'class-validator';
+
+function normalizeString(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value
+    .trim()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+}
+
+export class BuscaEmpresaFiltroDto {
+  @IsOptional()
+  @Transform(({ value }: TransformFnParams) => {
+    const normalized = normalizeString(value);
+    return typeof normalized === 'string'
+      ? normalized.toLowerCase()
+      : normalized;
+  })
+  @IsIn(['clinica', 'detran', 'vistoria'], {
+    message: 'Campo "tipo" deve ser "detran", "clinica" ou "vistoria"',
+  })
+  @ApiPropertyOptional({
+    description: 'Tipo da empresa para filtrar os resultados',
+    example: 'detran',
+    enum: ['clinica', 'detran', 'vistoria'],
+  })
+  declare tipo?: 'clinica' | 'detran' | 'vistoria';
+
+  @IsOptional()
+  @Transform(({ value }: TransformFnParams) => {
+    const normalized = normalizeString(value);
+    return typeof normalized === 'string'
+      ? normalized.toUpperCase()
+      : normalized;
+  })
+  @IsString()
+  @Matches(/^[A-Z]{2}$/, {
+    message: 'Campo "estado" deve ser uma UF válida (ex: SP, PR, ES)',
+  })
+  @ApiPropertyOptional({
+    description: 'UF (estado) da empresa para filtrar os resultados',
+    example: 'SP',
+    type: String,
+  })
+  declare estado?: string;
+
+  @IsOptional()
+  @Transform(({ value }: TransformFnParams) => {
+    const normalized = normalizeString(value);
+    return typeof normalized === 'string' ? normalized : normalized;
+  })
+  @IsString()
+  @ApiPropertyOptional({
+    description: 'Cidade da empresa para filtrar os resultados',
+    example: 'Curitiba',
+    type: String,
+  })
+  declare cidade?: string;
+}

--- a/src/modules/busca/dto/busca-empresa-filtro.dto.ts
+++ b/src/modules/busca/dto/busca-empresa-filtro.dto.ts
@@ -49,7 +49,7 @@ export class BuscaEmpresaFiltroDto {
   @IsOptional()
   @Transform(({ value }: TransformFnParams) => {
     const normalized = normalizeString(value);
-    return typeof normalized === 'string' ? normalized : normalized;
+    return normalized;
   })
   @IsString()
   @ApiPropertyOptional({

--- a/src/modules/busca/dto/busca-usuario-filtro.dto.ts
+++ b/src/modules/busca/dto/busca-usuario-filtro.dto.ts
@@ -1,10 +1,4 @@
-import {
-  IsOptional,
-  IsString,
-  Matches,
-  IsDateString,
-  IsIn,
-} from 'class-validator';
+import { IsOptional, IsString, IsDateString, IsIn } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class BuscaUsuarioFiltroDto {


### PR DESCRIPTION
**O que foi feito**

Este PR adiciona suporte de busca por filtros para **Empresas**, seguindo o mesmo padrão já existente nos endpoints de busca (Serviços/Usuários). Além disso, cria endpoints auxiliares para popular os filtros de **Estado** e **Cidade** diretamente a partir dos dados cadastrados na tabela `empresa`, garantindo que o frontend só exiba opções realmente disponíveis no banco.

**O que foi implementado**
- Novo endpoint de busca: `GET /busca/empresa/filtros`
  - Filtros opcionais: `tipo` (`clinica|detran|vistoria`), `estado` (UF), `cidade`
- Endpoint para popular o filtro de estados (UFs): `GET /busca/empresa/estados`
  - Retorna somente UFs **únicas** existentes nas empresas
- Endpoint para popular o filtro de cidades: `GET /busca/empresa/cidades`
  - Sem `estado`: retorna **todas** as cidades únicas cadastradas nas empresas
  - Com `estado`: retorna somente as cidades únicas das empresas daquela UF

**Regras atendidas (Estado x Cidade)**
- Ao abrir o filtro de cidade:
  - Se **não** houver estado selecionado → lista todas as cidades únicas da tabela `empresa`
  - Se houver estado selecionado → lista apenas cidades únicas daquele estado

**Alterações no Model `Empresa`**
Foi necessário atualizar o model `Empresa` para refletir corretamente as colunas existentes na tabela `empresa`, pois alguns campos não estavam mapeados:
- Adicionado `tipo` (`ENUM('clinica','vistoria','detran')`) para permitir filtro por tipo.
- Adicionado `latitude` e `longitude` (string) para manter o model alinhado ao schema da tabela e permitir retorno completo quando necessário.

**Validação**
- Adicionados testes unitários para os novos métodos de busca/listagem de empresas no `BuscaService`.
- Testes executados com sucesso (`jest` para busca.service.spec.ts).

closes #234 