### PR TITLE
feat: implementa recomendação proativa de licenciamento anual

### DIFF
--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -230,6 +230,91 @@ describe('RecomendacaoService', () => {
     });
   });
 
+  describe('buscarLicenciamentoAnual', () => {
+    it('deve retornar recomendação de licenciamento se o veículo estiver no período e não houver solicitação ativa', async () => {
+      const mesAtual = new Date().getMonth() + 1;
+
+      // Encontrar um dígito cujo gatilho seja <= mesAtual
+      const gatilhoPorDigito: Record<string, number> = {
+        '1': 3,
+        '2': 4,
+        '3': 5,
+        '4': 6,
+        '5': 7,
+        '6': 7,
+        '7': 8,
+        '8': 9,
+        '9': 10,
+        '0': 11,
+      };
+      const digitoElegivel =
+        Object.entries(gatilhoPorDigito).find(
+          ([, gatilho]) => mesAtual >= gatilho,
+        )?.[0] ?? '1';
+
+      mockVeiculoModel.findAll.mockResolvedValue([
+        { id: 5, placa: `ABC123${digitoElegivel}` } as unknown as Veiculo,
+      ]);
+      mockSolicitacaoModel.findOne.mockResolvedValue(null);
+
+      const resultado = await service.buscarLicenciamentoAnual(1);
+
+      expect(resultado).not.toBeNull();
+      expect(resultado?.id).toBe(1);
+      expect(resultado?.nome).toBe('Licenciamento Anual');
+    });
+
+    it('deve retornar null se o veículo ainda não atingiu o mês de gatilho', async () => {
+      // Dígito '0' tem gatilho em novembro (11), só dispara se mesAtual >= 11
+      // Forçamos um cenário onde o mês atual é anterior ao gatilho
+      mockVeiculoModel.findAll.mockResolvedValue([
+        { id: 5, placa: 'ABC1230', ativo: true } as unknown as Veiculo,
+      ]);
+
+      jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0); // Janeiro
+
+      const resultado = await service.buscarLicenciamentoAnual(1);
+      expect(resultado).toBeNull();
+
+      jest.restoreAllMocks();
+    });
+
+    it('deve retornar null se já existe solicitação ativa no ano corrente', async () => {
+      const mesAtual = new Date().getMonth() + 1;
+      const gatilhoPorDigito: Record<string, number> = {
+        '1': 3,
+        '2': 4,
+        '3': 5,
+        '4': 6,
+        '5': 7,
+        '6': 7,
+        '7': 8,
+        '8': 9,
+        '9': 10,
+        '0': 11,
+      };
+      const digitoElegivel =
+        Object.entries(gatilhoPorDigito).find(
+          ([, gatilho]) => mesAtual >= gatilho,
+        )?.[0] ?? '1';
+
+      mockVeiculoModel.findAll.mockResolvedValue([
+        {
+          id: 5,
+          placa: `ABC123${digitoElegivel}`,
+          ativo: true,
+        } as unknown as Veiculo,
+      ]);
+      mockSolicitacaoModel.findOne.mockResolvedValue({
+        id: 99,
+        status: 'pendente',
+      } as unknown as Solicitacao);
+
+      const resultado = await service.buscarLicenciamentoAnual(1);
+      expect(resultado).toBeNull();
+    });
+  });
+
   describe('buscarComunicacaoVenda', () => {
     it('deve retornar recomendação (ID 9) quando houver interesse no blog (Documentação)', async () => {
       mockInteracaoUsuarioModel.findOne.mockResolvedValue({
@@ -279,6 +364,7 @@ describe('RecomendacaoService', () => {
 
   describe('obterRecomendacoes', () => {
     it('deve retornar uma lista com múltiplos serviços se o usuário tiver multa e venda', async () => {
+      jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue({
         id: 6,
         nome: 'Multa',
@@ -304,6 +390,7 @@ describe('RecomendacaoService', () => {
     });
 
     it('deve retornar serviços populares se a lista de prioridades estiver vazia', async () => {
+      jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue(null);
       jest.spyOn(service, 'buscarParcelamentoDebitos').mockResolvedValue(null);
       jest.spyOn(service, 'buscarComunicacaoVenda').mockResolvedValue(null);

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -38,6 +38,9 @@ export class RecomendacaoService {
     try {
       const listaRecomendacoes: RecomendacaoRespostaDto[] = [];
 
+      const licenciamento = await this.buscarLicenciamentoAnual(usuarioId); // << ADICIONAR
+      if (licenciamento) listaRecomendacoes.push(licenciamento);
+
       const infracao = await this.buscarRecursoMulta(usuarioId);
       if (infracao) {
         listaRecomendacoes.push(infracao);
@@ -252,6 +255,73 @@ export class RecomendacaoService {
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(
         `Erro na busca de comunicação de venda: ${errorMessage}`,
+      );
+      return null;
+    }
+  }
+
+  async buscarLicenciamentoAnual(
+    usuarioId: number,
+  ): Promise<RecomendacaoRespostaDto | null> {
+    const gatilhoPorDigito: Record<string, number> = {
+      '1': 3,
+      '2': 4,
+      '3': 5,
+      '4': 6,
+      '5': 7,
+      '6': 7,
+      '7': 8,
+      '8': 9,
+      '9': 10,
+      '0': 11,
+    };
+
+    try {
+      const veiculos = await this.veiculoModel.findAll({
+        where: { usuarioId },
+      });
+
+      const mesAtual = new Date().getMonth() + 1;
+      const anoAtual = new Date().getFullYear();
+
+      for (const veiculo of veiculos) {
+        const ultimoDigito = veiculo.placa.slice(-1);
+        const mesGatilho = gatilhoPorDigito[ultimoDigito];
+
+        if (mesAtual < mesGatilho) continue;
+
+        const jaExiste = await this.solicitacaoModel.findOne({
+          where: {
+            veiculoId: veiculo.id,
+            servicoId: 1,
+            status: {
+              [Op.notIn]: ['cancelado', 'concluido'],
+            },
+            dataSolicitacao: {
+              [Op.between]: [
+                new Date(`${anoAtual}-01-01`),
+                new Date(`${anoAtual}-12-31`),
+              ],
+            },
+          },
+        });
+
+        if (!jaExiste) {
+          return {
+            id: 1,
+            nome: 'Licenciamento Anual',
+            descricao: `O veículo de placa ${veiculo.placa} já está no período de licenciamento. Faça o licenciamento anual para evitar multas.`,
+            ativo: true,
+          };
+        }
+      }
+
+      return null;
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erro desconhecido';
+      this.logger.error(
+        `Erro na busca de licenciamento anual: ${errorMessage}`,
       );
       return null;
     }


### PR DESCRIPTION
## Descrição

Esta branch implementa a lógica proativa para recomendar o serviço de Licenciamento Anual (ID 1). O objetivo é tornar o algoritmo de recomendações mais proativo para serviços obrigatórios, alertando o usuário no momento certo com base no último dígito da placa do veículo.

O método `buscarLicenciamentoAnual` foi adicionado em `recomendacao.service.ts` e é chamado como primeira verificação dentro de `obterRecomendacoes`.

---

## Lógica implementada

Antes de consultar o banco, o método valida se o veículo está no período de recomendação (1 mês de antecedência ao vencimento) com base no último dígito da placa:

| Último dígito | Vencimento | Gatilho |
|---|---|---|
| 1 | Abril | Março |
| 2 | Maio | Abril |
| 3 | Junho | Maio |
| 4 | Julho | Junho |
| 5 e 6 | Agosto | Julho |
| 7 | Setembro | Agosto |
| 8 | Outubro | Setembro |
| 9 | Novembro | Outubro |
| 0 | Dezembro | Novembro |

Se `mês atual >= mês de gatilho`, o veículo é elegível e o método consulta a tabela `Solicitacao` verificando se já existe registro com:
- `servico_id = 1`
- `status` diferente de `cancelado` ou `concluido`
- `data_solicitacao` entre `01/01` e `31/12` do ano corrente

Se não existir solicitação ativa, retorna a recomendação. Caso contrário, retorna `null` e o fluxo segue para o próximo nível de prioridade (renovação de CNH — próxima issue).

---

## Como testar

**Pré-requisitos:**
- Subir o banco com `docker compose -f compose.dev.yml up --build -d` no repositório `database`
- Subir o servidor com `npm run start:dev` no repositório `back-end`
- Acessar o Swagger em `http://localhost:3000/swagger`

**Passo a passo:**

1. Acesse `GET /recomendacoes/{usuarioId}`
2. Use o `usuarioId: 2` — este usuário possui o veículo de placa `YZA9I12` (último dígito `2`, gatilho em abril)
3. O retorno esperado é:

```json
[
  {
    "id": 1,
    "nome": "Licenciamento Anual",
    "descricao": "O veículo de placa YZA9I12 já está no período de licenciamento. Faça o licenciamento anual para evitar multas."
  }
]
```

4. Para testar o cenário negativo (veículo fora do período), use `usuarioId: 1` — nenhum veículo elegível, o algoritmo segue para as recomendações por histórico/popularidade.

---

## Observações

- O campo `rejeitado` não existe no ENUM de status da tabela `Solicitacao`. Por isso, o filtro usa `cancelado` e `concluido` como status a excluir, cobrindo o mesmo comportamento esperado pela issue.
- Quando a issue de renovação de CNH for implementada, os return null do método serão substituídos por return await this.buscarRenovacaoCNH(usuarioId).
---
Closes #154 