### PR TITLE
233 feature implementação da busca simples para cms de empresas

### DIFF
--- a/src/modules/busca/busca.controller.spec.ts
+++ b/src/modules/busca/busca.controller.spec.ts
@@ -9,6 +9,7 @@ describe('BuscaController', () => {
     listarBannersByTermo: jest.fn(),
     listarPublicidadeByTermo: jest.fn(),
     listarUsuariosByTermo: jest.fn(),
+    listarEmpresasByTermo: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -16,6 +17,7 @@ describe('BuscaController', () => {
     buscaServiceMock.listarBannersByTermo.mockReset();
     buscaServiceMock.listarPublicidadeByTermo.mockReset();
     buscaServiceMock.listarUsuariosByTermo.mockReset();
+    buscaServiceMock.listarEmpresasByTermo.mockReset();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [BuscaController],
@@ -65,6 +67,16 @@ describe('BuscaController', () => {
 
     expect(buscaServiceMock.listarPublicidadeByTermo).toHaveBeenCalledWith(
       'promo',
+    );
+  });
+
+  it('deve delegar a listagem de empresas para o BuscaService', async () => {
+    buscaServiceMock.listarEmpresasByTermo.mockResolvedValue({ itens: [] });
+
+    await controller.listarEmpresas('curitiba');
+
+    expect(buscaServiceMock.listarEmpresasByTermo).toHaveBeenCalledWith(
+      'curitiba',
     );
   });
 });

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -16,7 +16,7 @@ import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
 @Controller('busca')
 export class BuscaController {
   private readonly logger = new Logger(BuscaController.name);
-  constructor(private readonly buscaService: BuscaService) { }
+  constructor(private readonly buscaService: BuscaService) {}
 
   @Get('blog/periodo')
   @ApiOperation({

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -134,6 +134,21 @@ export class BuscaController {
     return this.buscaService.buscarEmpresasPorFiltros(dto);
   }
 
+  @Get('empresa/termo')
+  @ApiOperation({
+    summary:
+      'Buscar empresas do CMS por nome fantasia, CNPJ, telefone, cidade ou site',
+  })
+  listarEmpresas(@Query('termo') termo?: string): Promise<{
+    itens: Empresa[];
+    mensagem?: string;
+  }> {
+    this.logger.log(
+      `Listando empresas do CMS com filtro: ${termo?.trim() ?? 'sem filtro'}`,
+    );
+    return this.buscaService.listarEmpresasByTermo(termo);
+  }
+
   @Get('empresa/estados')
   @ApiOperation({
     summary: 'Listar UFs (estados) disponíveis nas empresas',

--- a/src/modules/busca/busca.controller.ts
+++ b/src/modules/busca/busca.controller.ts
@@ -16,7 +16,7 @@ import { BuscaUsuarioFiltroDto } from './dto/busca-usuario-filtro.dto';
 @Controller('busca')
 export class BuscaController {
   private readonly logger = new Logger(BuscaController.name);
-  constructor(private readonly buscaService: BuscaService) {}
+  constructor(private readonly buscaService: BuscaService) { }
 
   @Get('blog/periodo')
   @ApiOperation({

--- a/src/modules/busca/busca.service.spec.ts
+++ b/src/modules/busca/busca.service.spec.ts
@@ -216,6 +216,50 @@ describe('BuscaService', () => {
     });
   });
 
+  describe('listarEmpresasByTermo', () => {
+    it('deve retornar mensagem quando nao encontrar itens sem filtro', async () => {
+      empresaFindAllMock.mockResolvedValue([]);
+
+      const resultado = await service.listarEmpresasByTermo();
+
+      expect(empresaFindAllMock).toHaveBeenCalledWith({
+        order: [['id', 'DESC']],
+      });
+      expect(resultado).toEqual({
+        itens: [],
+        mensagem: 'Nenhum item foi encontrado.',
+      });
+    });
+
+    it('deve montar filtro por nome fantasia, cnpj, telefone, cidade e site quando termo textual for informado', async () => {
+      empresaFindAllMock.mockResolvedValue([]);
+
+      await service.listarEmpresasByTermo('  curitiba  ');
+
+      expect(empresaFindAllMock).toHaveBeenCalledWith({
+        where: {
+          [Op.or]: [
+            { nomeFantasia: { [Op.like]: '%curitiba%' } },
+            { cnpj: { [Op.like]: '%curitiba%' } },
+            { telefone: { [Op.like]: '%curitiba%' } },
+            { cidade: { [Op.like]: '%curitiba%' } },
+            { site: { [Op.like]: '%curitiba%' } },
+          ],
+        },
+        order: [['id', 'DESC']],
+      });
+    });
+
+    it('deve retornar itens quando houver correspondencia no filtro', async () => {
+      const retorno = [{ id: 10, nomeFantasia: 'Auto Curitiba' }];
+      empresaFindAllMock.mockResolvedValue(retorno);
+
+      const resultado = await service.listarEmpresasByTermo('curitiba');
+
+      expect(resultado).toEqual({ itens: retorno, mensagem: undefined });
+    });
+  });
+
   it('deve buscar blogs entre datas (incluindo limites)', async () => {
     const retorno = [{ id: 1 }];
     blogFindAllMock.mockResolvedValue(retorno);

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -194,6 +194,43 @@ export class BuscaService {
     return Array.from(new Set(valores));
   }
 
+  async listarEmpresasByTermo(termo?: string): Promise<{
+    itens: Empresa[];
+    mensagem?: string;
+  }> {
+    const termoNormalizado = termo?.trim();
+
+    if (!termoNormalizado) {
+      const itens = await this.empresaModel.findAll({
+        order: [['id', 'DESC']],
+      });
+
+      return {
+        itens,
+        mensagem:
+          itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
+      };
+    }
+
+    const filtros: Array<Record<string, unknown>> = [
+      { nomeFantasia: { [Op.like]: `%${termoNormalizado}%` } },
+      { cnpj: { [Op.like]: `%${termoNormalizado}%` } },
+      { telefone: { [Op.like]: `%${termoNormalizado}%` } },
+      { cidade: { [Op.like]: `%${termoNormalizado}%` } },
+      { site: { [Op.like]: `%${termoNormalizado}%` } },
+    ];
+
+    const itens = await this.empresaModel.findAll({
+      where: { [Op.or]: filtros },
+      order: [['id', 'DESC']],
+    });
+
+    return {
+      itens,
+      mensagem: itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
+    };
+  }
+
   private parseYmdDate(
     valor: string,
     campo: string,

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -23,7 +23,7 @@ export class BuscaService {
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
     @InjectModel(Empresa) private empresaModel: typeof Empresa,
-  ) {}
+  ) { }
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -23,7 +23,7 @@ export class BuscaService {
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
     @InjectModel(Empresa) private empresaModel: typeof Empresa,
-  ) { }
+  ) {}
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,


### PR DESCRIPTION
Foi adicionado um novo endpoint de busca simples para empresas no módulo de busca:

- `busca.controller.ts:137`

O controller passou a delegar a consulta para o service, mantendo o padrão já utilizado nos outros endpoints por termo:

- `busca.controller.ts:142`

---

## Regras implementadas na busca (Service)

Foi criado o método de busca textual de empresas:

- `busca.service.ts:197`

### Fluxo sem termo
- Quando o termo não é informado, retorna a listagem completa ordenada por **id DESC**.

### Fluxo com termo
- Aplica filtro automático com **OR** nos campos:
  - Nome Fantasia  
  - CNPJ  
  - Telefone  
  - Cidade  
  - Site  

### Fluxo sem resultados
- Retorna o payload no padrão do módulo com mensagem:
  - `Nenhum item foi encontrado.`

### Formato de resposta
- Retorno padronizado:
  ```json
  { "itens": [], "mensagem": "opcional" }
## Cobertura de testes no Backend

### Controller
- Inclusão de teste para garantir que o endpoint delega corretamente para o service:
  - `busca.controller.spec.ts:74`

### Service
- Inclusão de testes para:
  - cenário sem termo e sem resultados (mensagem de vazio);
  - cenário com termo textual e validação dos filtros;
  - cenário com retorno de itens.

closes #233