### PR TITLE
Feat: recomendar serviço de renovação de CNH

### DIFF
--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -230,6 +230,91 @@ describe('RecomendacaoService', () => {
     });
   });
 
+  describe('buscarLicenciamentoAnual', () => {
+    it('deve retornar recomendação de licenciamento se o veículo estiver no período e não houver solicitação ativa', async () => {
+      const mesAtual = new Date().getMonth() + 1;
+
+      // Encontrar um dígito cujo gatilho seja <= mesAtual
+      const gatilhoPorDigito: Record<string, number> = {
+        '1': 3,
+        '2': 4,
+        '3': 5,
+        '4': 6,
+        '5': 7,
+        '6': 7,
+        '7': 8,
+        '8': 9,
+        '9': 10,
+        '0': 11,
+      };
+      const digitoElegivel =
+        Object.entries(gatilhoPorDigito).find(
+          ([, gatilho]) => mesAtual >= gatilho,
+        )?.[0] ?? '1';
+
+      mockVeiculoModel.findAll.mockResolvedValue([
+        { id: 5, placa: `ABC123${digitoElegivel}` } as unknown as Veiculo,
+      ]);
+      mockSolicitacaoModel.findOne.mockResolvedValue(null);
+
+      const resultado = await service.buscarLicenciamentoAnual(1);
+
+      expect(resultado).not.toBeNull();
+      expect(resultado?.id).toBe(1);
+      expect(resultado?.nome).toBe('Licenciamento Anual');
+    });
+
+    it('deve retornar null se o veículo ainda não atingiu o mês de gatilho', async () => {
+      // Dígito '0' tem gatilho em novembro (11), só dispara se mesAtual >= 11
+      // Forçamos um cenário onde o mês atual é anterior ao gatilho
+      mockVeiculoModel.findAll.mockResolvedValue([
+        { id: 5, placa: 'ABC1230', ativo: true } as unknown as Veiculo,
+      ]);
+
+      jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0); // Janeiro
+
+      const resultado = await service.buscarLicenciamentoAnual(1);
+      expect(resultado).toBeNull();
+
+      jest.restoreAllMocks();
+    });
+
+    it('deve retornar null se já existe solicitação ativa no ano corrente', async () => {
+      const mesAtual = new Date().getMonth() + 1;
+      const gatilhoPorDigito: Record<string, number> = {
+        '1': 3,
+        '2': 4,
+        '3': 5,
+        '4': 6,
+        '5': 7,
+        '6': 7,
+        '7': 8,
+        '8': 9,
+        '9': 10,
+        '0': 11,
+      };
+      const digitoElegivel =
+        Object.entries(gatilhoPorDigito).find(
+          ([, gatilho]) => mesAtual >= gatilho,
+        )?.[0] ?? '1';
+
+      mockVeiculoModel.findAll.mockResolvedValue([
+        {
+          id: 5,
+          placa: `ABC123${digitoElegivel}`,
+          ativo: true,
+        } as unknown as Veiculo,
+      ]);
+      mockSolicitacaoModel.findOne.mockResolvedValue({
+        id: 99,
+        status: 'pendente',
+      } as unknown as Solicitacao);
+
+      const resultado = await service.buscarLicenciamentoAnual(1);
+      expect(resultado).toBeNull();
+    });
+  });
+
   describe('buscarComunicacaoVenda', () => {
     it('deve retornar recomendação (ID 9) quando houver interesse no blog (Documentação)', async () => {
       mockInteracaoUsuarioModel.findOne.mockResolvedValue({
@@ -279,6 +364,7 @@ describe('RecomendacaoService', () => {
 
   describe('obterRecomendacoes', () => {
     it('deve retornar uma lista com múltiplos serviços se o usuário tiver multa e venda', async () => {
+      jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue({
         id: 6,
         nome: 'Multa',
@@ -304,6 +390,7 @@ describe('RecomendacaoService', () => {
     });
 
     it('deve retornar serviços populares se a lista de prioridades estiver vazia', async () => {
+      jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue(null);
       jest.spyOn(service, 'buscarParcelamentoDebitos').mockResolvedValue(null);
       jest.spyOn(service, 'buscarComunicacaoVenda').mockResolvedValue(null);

--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -264,16 +264,20 @@ describe('RecomendacaoService', () => {
       expect(resultado?.nome).toBe('Licenciamento Anual');
     });
 
-    it('deve retornar null se o veículo ainda não atingiu o mês de gatilho', async () => {
-      // Dígito '0' tem gatilho em novembro (11), só dispara se mesAtual >= 11
-      // Forçamos um cenário onde o mês atual é anterior ao gatilho
+    it('deve seguir para buscarRenovacaoCNH se o veículo não atingiu o mês de gatilho', async () => {
       mockVeiculoModel.findAll.mockResolvedValue([
-        { id: 5, placa: 'ABC1230', ativo: true } as unknown as Veiculo,
+        { id: 5, placa: 'ABC1230' } as unknown as Veiculo,
       ]);
 
       jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0); // Janeiro
 
+      const spyCNH = jest
+        .spyOn(service, 'buscarRenovacaoCNH')
+        .mockResolvedValue(null);
+
       const resultado = await service.buscarLicenciamentoAnual(1);
+
+      expect(spyCNH).toHaveBeenCalledWith(1);
       expect(resultado).toBeNull();
 
       jest.restoreAllMocks();
@@ -311,6 +315,40 @@ describe('RecomendacaoService', () => {
       } as unknown as Solicitacao);
 
       const resultado = await service.buscarLicenciamentoAnual(1);
+      expect(resultado).toBeNull();
+    });
+  });
+
+  describe('buscarRenovacaoCNH', () => {
+    it('deve retornar recomendação (ID 4) se não houver solicitação nos últimos 10 anos', async () => {
+      mockSolicitacaoModel.findOne.mockResolvedValue(null);
+
+      const resultado = await service.buscarRenovacaoCNH(1);
+
+      expect(resultado).not.toBeNull();
+      expect(resultado?.id).toBe(4);
+      expect(resultado?.nome).toBe('Renovação de CNH');
+    });
+
+    it('deve retornar null se já existe solicitação ativa nos últimos 10 anos', async () => {
+      mockSolicitacaoModel.findOne.mockResolvedValue({
+        id: 50,
+        servicoId: 4,
+        status: 'concluido',
+      } as unknown as Solicitacao);
+
+      const resultado = await service.buscarRenovacaoCNH(1);
+
+      expect(resultado).toBeNull();
+    });
+
+    it('deve retornar null em caso de erro técnico para não travar o fluxo', async () => {
+      mockSolicitacaoModel.findOne.mockRejectedValue(
+        new Error('Erro de banco'),
+      );
+
+      const resultado = await service.buscarRenovacaoCNH(1);
+
       expect(resultado).toBeNull();
     });
   });
@@ -365,6 +403,7 @@ describe('RecomendacaoService', () => {
   describe('obterRecomendacoes', () => {
     it('deve retornar uma lista com múltiplos serviços se o usuário tiver multa e venda', async () => {
       jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
+      jest.spyOn(service, 'buscarRenovacaoCNH').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue({
         id: 6,
         nome: 'Multa',
@@ -391,6 +430,7 @@ describe('RecomendacaoService', () => {
 
     it('deve retornar serviços populares se a lista de prioridades estiver vazia', async () => {
       jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
+      jest.spyOn(service, 'buscarRenovacaoCNH').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue(null);
       jest.spyOn(service, 'buscarParcelamentoDebitos').mockResolvedValue(null);
       jest.spyOn(service, 'buscarComunicacaoVenda').mockResolvedValue(null);

--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -264,20 +264,15 @@ describe('RecomendacaoService', () => {
       expect(resultado?.nome).toBe('Licenciamento Anual');
     });
 
-    it('deve seguir para buscarRenovacaoCNH se o veículo não atingiu o mês de gatilho', async () => {
+    it('deve retornar null se o veículo não atingiu o mês de gatilho', async () => {
       mockVeiculoModel.findAll.mockResolvedValue([
         { id: 5, placa: 'ABC1230' } as unknown as Veiculo,
       ]);
 
       jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0); // Janeiro
 
-      const spyCNH = jest
-        .spyOn(service, 'buscarRenovacaoCNH')
-        .mockResolvedValue(null);
-
       const resultado = await service.buscarLicenciamentoAnual(1);
 
-      expect(spyCNH).toHaveBeenCalledWith(1);
       expect(resultado).toBeNull();
 
       jest.restoreAllMocks();

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -41,6 +41,9 @@ export class RecomendacaoService {
       const licenciamento = await this.buscarLicenciamentoAnual(usuarioId);
       if (licenciamento) listaRecomendacoes.push(licenciamento);
 
+      const cnh = await this.buscarRenovacaoCNH(usuarioId);
+      if (cnh) listaRecomendacoes.push(cnh);
+
       const infracao = await this.buscarRecursoMulta(usuarioId);
       if (infracao) {
         listaRecomendacoes.push(infracao);
@@ -129,7 +132,7 @@ export class RecomendacaoService {
               servicoId: 6,
               veiculoId: veiculo.id,
               status: {
-                [Op.notIn]: ['concluido', 'cancelado'],
+                [Op.notIn]: ['cancelado', 'rejeitado'],
               },
             },
           });
@@ -295,7 +298,7 @@ export class RecomendacaoService {
             veiculoId: veiculo.id,
             servicoId: 1,
             status: {
-              [Op.notIn]: ['cancelado', 'concluido'],
+              [Op.notIn]: ['cancelado', 'rejeitado'],
             },
             dataSolicitacao: {
               [Op.between]: [
@@ -316,14 +319,14 @@ export class RecomendacaoService {
         }
       }
 
-      return await this.buscarRenovacaoCNH(usuarioId);
+      return null;
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(
         `Erro na busca de licenciamento anual: ${errorMessage}`,
       );
-      return await this.buscarRenovacaoCNH(usuarioId);
+      return null;
     }
   }
 
@@ -339,7 +342,7 @@ export class RecomendacaoService {
           usuarioId,
           servicoId: 4,
           status: {
-            [Op.notIn]: ['cancelado', 'concluido'],
+            [Op.notIn]: ['cancelado', 'rejeitado'],
           },
           dataSolicitacao: {
             [Op.gte]: dezAnosAtras,
@@ -356,20 +359,13 @@ export class RecomendacaoService {
         };
       }
 
-      return await this.buscarTransferenciaPropriedade(usuarioId);
+      return null;
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(`Erro na busca de renovação de CNH: ${errorMessage}`);
       return null;
     }
-  }
-
-  protected async buscarTransferenciaPropriedade(usuarioId: number) {
-    this.logger.log(
-      `Seguindo para Transferência de Propriedade para usuário ${usuarioId}`,
-    );
-    return Promise.resolve(null);
   }
 
   private async buscarServicosPopulares() {

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -38,7 +38,7 @@ export class RecomendacaoService {
     try {
       const listaRecomendacoes: RecomendacaoRespostaDto[] = [];
 
-      const licenciamento = await this.buscarLicenciamentoAnual(usuarioId); // << ADICIONAR
+      const licenciamento = await this.buscarLicenciamentoAnual(usuarioId);
       if (licenciamento) listaRecomendacoes.push(licenciamento);
 
       const infracao = await this.buscarRecursoMulta(usuarioId);
@@ -316,15 +316,60 @@ export class RecomendacaoService {
         }
       }
 
-      return null;
+      return await this.buscarRenovacaoCNH(usuarioId);
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(
         `Erro na busca de licenciamento anual: ${errorMessage}`,
       );
+      return await this.buscarRenovacaoCNH(usuarioId);
+    }
+  }
+
+  async buscarRenovacaoCNH(
+    usuarioId: number,
+  ): Promise<RecomendacaoRespostaDto | null> {
+    try {
+      const dezAnosAtras = new Date();
+      dezAnosAtras.setFullYear(dezAnosAtras.getFullYear() - 10);
+
+      const jaExiste = await this.solicitacaoModel.findOne({
+        where: {
+          usuarioId,
+          servicoId: 4,
+          status: {
+            [Op.notIn]: ['cancelado', 'concluido'],
+          },
+          dataSolicitacao: {
+            [Op.gte]: dezAnosAtras,
+          },
+        },
+      });
+
+      if (!jaExiste) {
+        return {
+          id: 4,
+          nome: 'Renovação de CNH',
+          descricao: 'Renove sua CNH',
+          ativo: true,
+        };
+      }
+
+      return await this.buscarTransferenciaPropriedade(usuarioId);
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erro desconhecido';
+      this.logger.error(`Erro na busca de renovação de CNH: ${errorMessage}`);
       return null;
     }
+  }
+
+  protected async buscarTransferenciaPropriedade(usuarioId: number) {
+    this.logger.log(
+      `Seguindo para Transferência de Propriedade para usuário ${usuarioId}`,
+    );
+    return Promise.resolve(null);
   }
 
   private async buscarServicosPopulares() {

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -38,6 +38,9 @@ export class RecomendacaoService {
     try {
       const listaRecomendacoes: RecomendacaoRespostaDto[] = [];
 
+      const licenciamento = await this.buscarLicenciamentoAnual(usuarioId); // << ADICIONAR
+      if (licenciamento) listaRecomendacoes.push(licenciamento);
+
       const infracao = await this.buscarRecursoMulta(usuarioId);
       if (infracao) {
         listaRecomendacoes.push(infracao);
@@ -252,6 +255,73 @@ export class RecomendacaoService {
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(
         `Erro na busca de comunicação de venda: ${errorMessage}`,
+      );
+      return null;
+    }
+  }
+
+  async buscarLicenciamentoAnual(
+    usuarioId: number,
+  ): Promise<RecomendacaoRespostaDto | null> {
+    const gatilhoPorDigito: Record<string, number> = {
+      '1': 3,
+      '2': 4,
+      '3': 5,
+      '4': 6,
+      '5': 7,
+      '6': 7,
+      '7': 8,
+      '8': 9,
+      '9': 10,
+      '0': 11,
+    };
+
+    try {
+      const veiculos = await this.veiculoModel.findAll({
+        where: { usuarioId },
+      });
+
+      const mesAtual = new Date().getMonth() + 1;
+      const anoAtual = new Date().getFullYear();
+
+      for (const veiculo of veiculos) {
+        const ultimoDigito = veiculo.placa.slice(-1);
+        const mesGatilho = gatilhoPorDigito[ultimoDigito];
+
+        if (mesAtual < mesGatilho) continue;
+
+        const jaExiste = await this.solicitacaoModel.findOne({
+          where: {
+            veiculoId: veiculo.id,
+            servicoId: 1,
+            status: {
+              [Op.notIn]: ['cancelado', 'concluido'],
+            },
+            dataSolicitacao: {
+              [Op.between]: [
+                new Date(`${anoAtual}-01-01`),
+                new Date(`${anoAtual}-12-31`),
+              ],
+            },
+          },
+        });
+
+        if (!jaExiste) {
+          return {
+            id: 1,
+            nome: 'Licenciamento Anual',
+            descricao: `O veículo de placa ${veiculo.placa} já está no período de licenciamento. Faça o licenciamento anual para evitar multas.`,
+            ativo: true,
+          };
+        }
+      }
+
+      return null;
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erro desconhecido';
+      this.logger.error(
+        `Erro na busca de licenciamento anual: ${errorMessage}`,
       );
       return null;
     }


### PR DESCRIPTION

## Descrição

Esta branch implementa a lógica proativa para recomendar o serviço de Renovação de CNH (ID 4). O método `buscarRenovacaoCNH` foi adicionado em `recomendacao.service.ts` e é chamado em cadeia pelo `buscarLicenciamentoAnual`, seguindo o fluxo de prioridades do algoritmo de recomendações.

---

## Lógica implementada

O método verifica na tabela `Solicitacao` se já existe registro onde:
- `servico_id = 4`
- `status` diferente de `cancelado` e `concluido`
- `data_solicitacao` nos últimos 10 anos

Se não existir solicitação, retorna a recomendação. Caso contrário, segue para o próximo nível de prioridade (Transferência de Propriedade — próxima issue).

---

## Como testar

**Pré-requisitos:**
- Subir o banco com `docker compose -f compose.dev.yml up --build -d` no repositório `database`
- Subir o servidor com `npm run start:dev` no repositório `back-end`
- Acessar o Swagger em `http://localhost:3000/swagger`

**Passo a passo:**

1. Acesse `GET /recomendacoes/{usuarioId}`

2. **Cenário positivo** — use `usuarioId: 3`
   - Não possui solicitação de CNH nos últimos 10 anos
   - Retorno esperado inclui `id: 4, nome: "Renovação de CNH"`

3. **Cenário negativo** — use `usuarioId: 5`
   - Possui solicitação de CNH com status `concluido` de 2026
   - Retorno **não deve** incluir `id: 4`

---

## Observações

- O método `buscarRenovacaoCNH` é chamado em cadeia pelo `buscarLicenciamentoAnual` não é chamado diretamente no `obterRecomendacoes` para evitar duplicidade.
---
closes #155 