### PR TITLE
239 feature separar as queries do dashboard em diferentes endpoints

### DIFF
--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { ApiQuery, ApiTags } from '@nestjs/swagger';
 import { DashboardService } from './dashboard.service';
-import { DashboardReturnDto } from './dto/dashboard-return.dto';
+import { DashboardReturnDto, GeralDto, ServicosDto, SolicitacoesDto } from './dto/dashboard-return.dto';
 import { DashboardPeriodoQueryDto } from './dto/dashboard-periodo-query.dto';
 
 @ApiTags('Dashboard')
@@ -9,16 +9,32 @@ import { DashboardPeriodoQueryDto } from './dto/dashboard-periodo-query.dto';
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
-  @Get()
+  @Get('/all')
   @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
-  async retornarInfosDashboard(
+  async retornarTudoDashboard(
     @Query() query: DashboardPeriodoQueryDto,
   ): Promise<DashboardReturnDto> {
     return this.dashboardService.retornoTotalDashboard(query.inicio, query.fim);
   }
 
+  @Get('/geral')
+  @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
+  @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
+  async retornarGeralDashboard(
+    @Query() query: DashboardPeriodoQueryDto,
+  ): Promise<GeralDto> {
+    return this.dashboardService.obterDadosGerais(query.inicio, query.fim);
+  }
+
+  @Get('/solicitacoes')
+  @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
+  @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
+  async retornarSolicitacoesDashboard(
+    @Query() query: DashboardPeriodoQueryDto,
+  ): Promise<SolicitacoesDto> {
+    return this.dashboardService.obterDadosSolicitacoes(query.inicio, query.fim);
+  }
 
 
-  
 }

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -47,9 +47,7 @@ export class DashboardController {
   }
 
   @Get('/veiculos')
-  async retornarVeiculosDashboard(
-    @Query() query: DashboardPeriodoQueryDto,
-  ): Promise<VeiculosDto> {
+  async retornarVeiculosDashboard(): Promise<VeiculosDto> {
     return this.dashboardService.obterDadosVeiculos();
   }
 

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -1,7 +1,13 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { ApiQuery, ApiTags } from '@nestjs/swagger';
 import { DashboardService } from './dashboard.service';
-import { DashboardReturnDto, GeralDto, ServicosDto, SolicitacoesDto } from './dto/dashboard-return.dto';
+import {
+  DashboardReturnDto,
+  GeralDto,
+  ServicosDto,
+  SolicitacoesDto,
+  VeiculosDto,
+} from './dto/dashboard-return.dto';
 import { DashboardPeriodoQueryDto } from './dto/dashboard-periodo-query.dto';
 
 @ApiTags('Dashboard')
@@ -33,8 +39,16 @@ export class DashboardController {
   async retornarSolicitacoesDashboard(
     @Query() query: DashboardPeriodoQueryDto,
   ): Promise<SolicitacoesDto> {
-    return this.dashboardService.obterDadosSolicitacoes(query.inicio, query.fim);
+    return this.dashboardService.obterDadosSolicitacoes(
+      query.inicio,
+      query.fim,
+    );
   }
 
-
+  @Get('/veiculos')
+  async retornarVeiculosDashboard(
+    @Query() query: DashboardPeriodoQueryDto,
+  ): Promise<VeiculosDto> {
+    return this.dashboardService.obterDadosVeiculos();
+  }
 }

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -3,6 +3,7 @@ import { ApiQuery, ApiTags } from '@nestjs/swagger';
 import { DashboardService } from './dashboard.service';
 import {
   DashboardReturnDto,
+  FinanceiroDto,
   GeralDto,
   ServicosDto,
   SolicitacoesDto,
@@ -50,5 +51,23 @@ export class DashboardController {
     @Query() query: DashboardPeriodoQueryDto,
   ): Promise<VeiculosDto> {
     return this.dashboardService.obterDadosVeiculos();
+  }
+
+  @Get('/servicos')
+  @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
+  @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
+  async retornarServicosDashboard(
+    @Query() query: DashboardPeriodoQueryDto,
+  ): Promise<ServicosDto> {
+    return this.dashboardService.obterDadosServicos(query.inicio, query.fim);
+  }
+
+  @Get('/financeiro')
+  @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
+  @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
+  async retornarFinanceiroDashboard(
+    @Query() query: DashboardPeriodoQueryDto,
+  ): Promise<FinanceiroDto> {
+    return this.dashboardService.obterDadosFinanceiro(query.inicio, query.fim);
   }
 }

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -16,7 +16,7 @@ import { DashboardPeriodoQueryDto } from './dto/dashboard-periodo-query.dto';
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
-  @Get('/all')
+  @Get('all')
   @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarTudoDashboard(
@@ -34,7 +34,7 @@ export class DashboardController {
     return this.dashboardService.obterDadosGerais(query.inicio, query.fim);
   }
 
-  @Get('/solicitacoes')
+  @Get('solicitacoes')
   @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarSolicitacoesDashboard(
@@ -46,12 +46,12 @@ export class DashboardController {
     );
   }
 
-  @Get('/veiculos')
+  @Get('veiculos')
   async retornarVeiculosDashboard(): Promise<VeiculosDto> {
     return this.dashboardService.obterDadosVeiculos();
   }
 
-  @Get('/servicos')
+  @Get('servicos')
   @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarServicosDashboard(
@@ -60,7 +60,7 @@ export class DashboardController {
     return this.dashboardService.obterDadosServicos(query.inicio, query.fim);
   }
 
-  @Get('/financeiro')
+  @Get('financeiro')
   @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarFinanceiroDashboard(

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -25,7 +25,7 @@ export class DashboardController {
     return this.dashboardService.retornoTotalDashboard(query.inicio, query.fim);
   }
 
-  @Get('/')
+  @Get()
   @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarGeralDashboard(

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -15,9 +15,10 @@ export class DashboardController {
   async retornarInfosDashboard(
     @Query() query: DashboardPeriodoQueryDto,
   ): Promise<DashboardReturnDto> {
-    return this.dashboardService.retornarInfosDashboard(
-      query.inicio,
-      query.fim,
-    );
+    return this.dashboardService.retornoTotalDashboard(query.inicio, query.fim);
   }
+
+
+
+  
 }

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -25,7 +25,7 @@ export class DashboardController {
     return this.dashboardService.retornoTotalDashboard(query.inicio, query.fim);
   }
 
-  @Get('/geral')
+  @Get('/')
   @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarGeralDashboard(

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -408,7 +408,7 @@ export class DashboardService {
   }
 
   /** Retorna dados de serviços: ativos, pausados e receita por serviço */
-  private async obterDadosServicos(
+  async obterDadosServicos(
     inicio?: string,
     fim?: string,
   ): Promise<ServicosDto> {
@@ -494,10 +494,11 @@ export class DashboardService {
   }
 
   /** Retorna dados financeiros: receita, débitos, parcelas, histórico mensal e distribuição de pagamentos */
-  private async obterDadosFinanceiro(
-    dataInicio: Date,
-    dataFim: Date,
+  async obterDadosFinanceiro(
+    inicio?: string,
+    fim?: string,
   ): Promise<FinanceiroDto> {
+    const { dataInicio, dataFim } = this.converterData(fim, inicio);
     const hoje = new Date();
     const em30Dias = new Date(hoje.getTime() + 30 * 24 * 60 * 60 * 1000);
 
@@ -669,7 +670,7 @@ export class DashboardService {
       this.obterDadosGerais(inicioParam, fimParam),
       this.obterDadosVeiculos(),
       this.obterDadosServicos(inicioParam, fimParam),
-      this.obterDadosFinanceiro(dataInicio, dataFim),
+      this.obterDadosFinanceiro(inicioParam, fimParam),
     ]);
 
     const solicitacoes = await this.obterDadosSolicitacoes(

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -94,56 +94,59 @@ export class DashboardService {
     const { dataInicio, dataFim } = this.converterData(fim, inicio);
     const hoje = new Date();
 
-    const porStatusRaw = (await this.solicitacaoModel.findAll({
-      attributes: [
-        'status',
-        [fn('COUNT', col('Solicitacao.id')), 'quantidade'],
-      ],
-      where: {
-        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
-      },
-      group: [col('Solicitacao.status')],
-      raw: true,
-    })) as unknown as StatusCountRaw[];
-
-    const documentosPendentesValidacao =
-      await this.documentoSolicitacaoModel.count({
+    const [
+      porStatusRaw,
+      documentosPendentesValidacao,
+      clientesNovosMesAtual,
+      solicitacoesConcluidas,
+      debitosEmAbertoQuantidade,
+      debitosEmAbertoValor,
+      parcelasVencidasResult,
+    ] = await Promise.all([
+      this.solicitacaoModel.findAll({
+        attributes: [
+          'status',
+          [fn('COUNT', col('Solicitacao.id')), 'quantidade'],
+        ],
+        where: {
+          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+        },
+        group: [col('Solicitacao.status')],
+        raw: true,
+      }) as unknown as Promise<StatusCountRaw[]>,
+      this.documentoSolicitacaoModel.count({
         where: { statusValidacao: 'pendente' },
-      });
-
-    const clientesNovosMesAtual = await this.usuarioModel.count({
-      where: {
-        nivel: 'cliente',
-        dataCadastro: { [Op.between]: [dataInicio, dataFim] },
-      },
-    });
-
-    const solicitacoesConcluidas = await this.solicitacaoModel.count({
-      where: {
-        status: 'concluido',
-        dataConclusao: { [Op.between]: [dataInicio, dataFim] },
-      },
-    });
-
-    const debitosEmAbertoQuantidade = await this.debitoModel.count({
-      where: { status: 'pendente' },
-    });
-
-    const debitosEmAbertoValor = await this.debitoModel.sum('valor', {
-      where: { status: 'pendente' },
-    });
-
-    const parcelasVencidasResult = (await this.parcelaModel.findOne({
-      attributes: [
-        [fn('SUM', col('valor')), 'valorTotal'],
-        [fn('COUNT', col('id')), 'quantidadeParcelas'],
-      ],
-      where: {
-        vencimento: { [Op.lt]: hoje },
-        status: { [Op.ne]: 'pago' },
-      },
-      raw: true,
-    })) as ParcelasVencidasRaw | null;
+      }),
+      this.usuarioModel.count({
+        where: {
+          nivel: 'cliente',
+          dataCadastro: { [Op.between]: [dataInicio, dataFim] },
+        },
+      }),
+      this.solicitacaoModel.count({
+        where: {
+          status: 'concluido',
+          dataConclusao: { [Op.between]: [dataInicio, dataFim] },
+        },
+      }),
+      this.debitoModel.count({
+        where: { status: 'pendente' },
+      }),
+      this.debitoModel.sum('valor', {
+        where: { status: 'pendente' },
+      }),
+      this.parcelaModel.findOne({
+        attributes: [
+          [fn('SUM', col('valor')), 'valorTotal'],
+          [fn('COUNT', col('id')), 'quantidadeParcelas'],
+        ],
+        where: {
+          vencimento: { [Op.lt]: hoje },
+          status: { [Op.ne]: 'pago' },
+        },
+        raw: true,
+      }) as Promise<ParcelasVencidasRaw | null>,
+    ]);
 
     const porStatusBase = {
       recebido: 0,
@@ -216,17 +219,88 @@ export class DashboardService {
       'em_andamento',
     ];
 
-    const porStatusRaw = (await this.solicitacaoModel.findAll({
-      attributes: [
-        'status',
-        [fn('COUNT', col('Solicitacao.id')), 'quantidade'],
-      ],
-      where: {
-        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
-      },
-      group: [col('Solicitacao.status')],
-      raw: true,
-    })) as unknown as StatusCountRaw[];
+    const [
+      porStatusRaw,
+      proximasDeVencer,
+      tempoConclusaoRaw,
+      foraDoPrazoQuantidade,
+      totalConcluidas,
+    ] = await Promise.all([
+      this.solicitacaoModel.findAll({
+        attributes: [
+          'status',
+          [fn('COUNT', col('Solicitacao.id')), 'quantidade'],
+        ],
+        where: {
+          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+        },
+        group: [col('Solicitacao.status')],
+        raw: true,
+      }) as unknown as Promise<StatusCountRaw[]>,
+      this.solicitacaoModel.count({
+        include: [{ model: Servico, attributes: [], required: true }],
+        where: {
+          status: { [Op.in]: statusAbertos },
+          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+          [Op.and]: [
+            literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
+            literal(`
+            DATEDIFF(NOW(), \`Solicitacao\`.\`data_solicitacao\`)
+            BETWEEN GREATEST(\`servico\`.\`prazo_estimado_dias\` - ${this.DIAS_ALERTA_VENCIMENTO}, 0)
+            AND \`servico\`.\`prazo_estimado_dias\`
+          `),
+          ],
+        },
+      }),
+      this.solicitacaoModel.findAll({
+        attributes: [
+          [col('Solicitacao.servico_id'), 'servicoId'],
+          [col('servico.nome'), 'servicoNome'],
+          [col('servico.prazo_estimado_dias'), 'prazoEstimadoDias'],
+          [
+            fn(
+              'AVG',
+              literal(
+                'DATEDIFF(`Solicitacao`.`data_conclusao`, `Solicitacao`.`data_solicitacao`)',
+              ),
+            ),
+            'mediaRealDias',
+          ],
+          [fn('COUNT', col('Solicitacao.id')), 'totalConcluidas'],
+        ],
+        include: [{ model: Servico, attributes: [], required: true }],
+        where: {
+          status: 'concluido',
+          dataConclusao: { [Op.between]: [dataInicio, dataFim] },
+          [Op.and]: [literal('`servico`.`prazo_estimado_dias` IS NOT NULL')],
+        },
+        group: [
+          col('Solicitacao.servico_id'),
+          col('servico.id'),
+          col('servico.nome'),
+          col('servico.prazo_estimado_dias'),
+        ],
+        order: [[literal('mediaRealDias'), 'DESC']],
+        raw: true,
+      }) as unknown as Promise<TempoConclusaoRaw[]>,
+      this.solicitacaoModel.count({
+        include: [{ model: Servico, attributes: [], required: true }],
+        where: {
+          status: 'concluido',
+          dataConclusao: { [Op.between]: [dataInicio, dataFim] },
+          [Op.and]: [
+            literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
+            literal(`
+            DATEDIFF(\`Solicitacao\`.\`data_conclusao\`, \`Solicitacao\`.\`data_solicitacao\`)
+            > \`servico\`.\`prazo_estimado_dias\`
+          `),
+          ],
+        },
+      }),
+      this.solicitacaoModel.count({
+        where: { status: 'concluido' },
+      }),
+    ]);
 
     const porStatusBase = {
       recebido: 0,
@@ -249,73 +323,6 @@ export class DashboardService {
       if (item.status === 'cancelado') acc.cancelado = quantidade;
       return acc;
     }, porStatusBase);
-
-    const proximasDeVencer = await this.solicitacaoModel.count({
-      include: [{ model: Servico, attributes: [], required: true }],
-      where: {
-        status: { [Op.in]: statusAbertos },
-        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
-        [Op.and]: [
-          literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
-          literal(`
-            DATEDIFF(NOW(), \`Solicitacao\`.\`data_solicitacao\`)
-            BETWEEN GREATEST(\`servico\`.\`prazo_estimado_dias\` - ${this.DIAS_ALERTA_VENCIMENTO}, 0)
-            AND \`servico\`.\`prazo_estimado_dias\`
-          `),
-        ],
-      },
-    });
-
-    const tempoConclusaoRaw = (await this.solicitacaoModel.findAll({
-      attributes: [
-        [col('Solicitacao.servico_id'), 'servicoId'],
-        [col('servico.nome'), 'servicoNome'],
-        [col('servico.prazo_estimado_dias'), 'prazoEstimadoDias'],
-        [
-          fn(
-            'AVG',
-            literal(
-              'DATEDIFF(`Solicitacao`.`data_conclusao`, `Solicitacao`.`data_solicitacao`)',
-            ),
-          ),
-          'mediaRealDias',
-        ],
-        [fn('COUNT', col('Solicitacao.id')), 'totalConcluidas'],
-      ],
-      include: [{ model: Servico, attributes: [], required: true }],
-      where: {
-        status: 'concluido',
-        dataConclusao: { [Op.between]: [dataInicio, dataFim] },
-        [Op.and]: [literal('`servico`.`prazo_estimado_dias` IS NOT NULL')],
-      },
-      group: [
-        col('Solicitacao.servico_id'),
-        col('servico.id'),
-        col('servico.nome'),
-        col('servico.prazo_estimado_dias'),
-      ],
-      order: [[literal('mediaRealDias'), 'DESC']],
-      raw: true,
-    })) as unknown as TempoConclusaoRaw[];
-
-    const foraDoPrazoQuantidade = await this.solicitacaoModel.count({
-      include: [{ model: Servico, attributes: [], required: true }],
-      where: {
-        status: 'concluido',
-        dataConclusao: { [Op.between]: [dataInicio, dataFim] },
-        [Op.and]: [
-          literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
-          literal(`
-            DATEDIFF(\`Solicitacao\`.\`data_conclusao\`, \`Solicitacao\`.\`data_solicitacao\`)
-            > \`servico\`.\`prazo_estimado_dias\`
-          `),
-        ],
-      },
-    });
-
-    const totalConcluidas = await this.solicitacaoModel.count({
-      where: { status: 'concluido' },
-    });
 
     const tempoConclusaoPorServico = tempoConclusaoRaw.map((item) => ({
       servicoId: Number(item.servicoId),
@@ -344,45 +351,49 @@ export class DashboardService {
 
   /** Retorna dados de veículos: cadastrados, com solicitações ativas e débitos pendentes */
   async obterDadosVeiculos(): Promise<VeiculosDto> {
-    const totalVeiculosCadastrados = await this.veiculoModel.count();
-
-    const veiculosComSolicitacaoAtiva = await this.solicitacaoModel.count({
-      where: {
-        veiculoId: { [Op.ne]: null },
-        status: {
-          [Op.in]: [
-            'recebido',
-            'aguardando_pagamento',
-            'aguardando_documento',
-            'em_andamento',
-          ],
+    const [
+      totalVeiculosCadastrados,
+      veiculosComSolicitacaoAtiva,
+      debitosPendentesResult,
+    ] = await Promise.all([
+      this.veiculoModel.count(),
+      this.solicitacaoModel.count({
+        where: {
+          veiculoId: { [Op.ne]: null },
+          status: {
+            [Op.in]: [
+              'recebido',
+              'aguardando_pagamento',
+              'aguardando_documento',
+              'em_andamento',
+            ],
+          },
         },
-      },
-      distinct: true,
-      col: 'veiculo_id',
-    });
-
-    const debitosPendentesResult = (await this.debitoVeiculoModel.findAll({
-      include: [
-        {
-          model: Debito,
-          where: { status: 'pendente' },
-          attributes: [],
-        },
-        {
-          model: Veiculo,
-          attributes: ['id', 'placa'],
-        },
-      ],
-      attributes: [
-        'idVeiculo',
-        [fn('COUNT', col('DebitoVeiculo.id')), 'totalDebitos'],
-        [fn('SUM', col('debito.valor')), 'valorTotal'],
-      ],
-      group: ['idVeiculo', 'veiculo.id'],
-      raw: true,
-      nest: true,
-    })) as unknown as DebitoVeiculoRaw[];
+        distinct: true,
+        col: 'veiculo_id',
+      }),
+      this.debitoVeiculoModel.findAll({
+        include: [
+          {
+            model: Debito,
+            where: { status: 'pendente' },
+            attributes: [],
+          },
+          {
+            model: Veiculo,
+            attributes: ['id', 'placa'],
+          },
+        ],
+        attributes: [
+          'idVeiculo',
+          [fn('COUNT', col('DebitoVeiculo.id')), 'totalDebitos'],
+          [fn('SUM', col('debito.valor')), 'valorTotal'],
+        ],
+        group: ['idVeiculo', 'veiculo.id'],
+        raw: true,
+        nest: true,
+      }) as unknown as Promise<DebitoVeiculoRaw[]>,
+    ]);
 
     const porVeiculo = debitosPendentesResult.map((item) => ({
       veiculoId: item.idVeiculo,
@@ -413,52 +424,58 @@ export class DashboardService {
     fim?: string,
   ): Promise<ServicosDto> {
     const { dataInicio, dataFim } = this.converterData(fim, inicio);
-    const servicosAtivos = await this.servicoModel.count({
-      where: { ativo: true },
-    });
-
-    const servicosPausados = await this.servicoModel.count({
-      where: { [Op.or]: [{ ativo: false }, { ativo: null }] },
-    });
-
-    const maisSolicitadosRaw = (await this.solicitacaoModel.findAll({
-      attributes: [
-        [col('Solicitacao.servico_id'), 'servicoId'],
-        [fn('COUNT', col('Solicitacao.id')), 'totalSolicitacoes'],
-      ],
-      include: [{ model: Servico, attributes: ['id', 'nome'], as: 'servico' }],
-      where: {
-        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
-      },
-      group: ['servico.id', 'Solicitacao.servico_id'],
-      order: [[literal('totalSolicitacoes'), 'DESC']],
-      limit: 5,
-    })) as unknown as MaisSolicitadosRow[];
-
-    const receitaPorServicoRaw = (await this.debitoServicoModel.findAll({
-      attributes: [
-        [col('DebitoServico.id_servico'), 'servicoId'],
-        [fn('COUNT', col('DebitoServico.id')), 'totalSolicitacoes'],
-        [fn('SUM', col('debito.valor')), 'receitaTotal'],
-      ],
-      include: [
-        { model: Servico, attributes: ['id', 'nome'], as: 'servico' },
-        {
-          model: Debito,
-          attributes: [],
-          as: 'debito',
-          where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+    const [
+      servicosAtivos,
+      servicosPausados,
+      maisSolicitadosRaw,
+      receitaPorServicoRaw,
+      todosServicos,
+    ] = await Promise.all([
+      this.servicoModel.count({
+        where: { ativo: true },
+      }),
+      this.servicoModel.count({
+        where: { [Op.or]: [{ ativo: false }, { ativo: null }] },
+      }),
+      this.solicitacaoModel.findAll({
+        attributes: [
+          [col('Solicitacao.servico_id'), 'servicoId'],
+          [fn('COUNT', col('Solicitacao.id')), 'totalSolicitacoes'],
+        ],
+        include: [
+          { model: Servico, attributes: ['id', 'nome'], as: 'servico' },
+        ],
+        where: {
+          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
         },
-      ],
-      group: ['servico.id', 'DebitoServico.id_servico'],
-      order: [[literal('receitaTotal'), 'DESC']],
-      limit: 5,
-    })) as unknown as ReceitaPorServicoRow[];
-
-    const todosServicos = await this.servicoModel.findAll({
-      where: { ativo: true },
-      attributes: ['id', 'nome'],
-    });
+        group: ['servico.id', 'Solicitacao.servico_id'],
+        order: [[literal('totalSolicitacoes'), 'DESC']],
+        limit: 5,
+      }) as unknown as Promise<MaisSolicitadosRow[]>,
+      this.debitoServicoModel.findAll({
+        attributes: [
+          [col('DebitoServico.id_servico'), 'servicoId'],
+          [fn('COUNT', col('DebitoServico.id')), 'totalSolicitacoes'],
+          [fn('SUM', col('debito.valor')), 'receitaTotal'],
+        ],
+        include: [
+          { model: Servico, attributes: ['id', 'nome'], as: 'servico' },
+          {
+            model: Debito,
+            attributes: [],
+            as: 'debito',
+            where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+          },
+        ],
+        group: ['servico.id', 'DebitoServico.id_servico'],
+        order: [[literal('receitaTotal'), 'DESC']],
+        limit: 5,
+      }) as unknown as Promise<ReceitaPorServicoRow[]>,
+      this.servicoModel.findAll({
+        where: { ativo: true },
+        attributes: ['id', 'nome'],
+      }),
+    ]);
 
     const maisSolicitados = maisSolicitadosRaw.map((item) => ({
       servicoId: Number(item.get('servicoId') ?? 0),
@@ -502,84 +519,88 @@ export class DashboardService {
     const hoje = new Date();
     const em30Dias = new Date(hoje.getTime() + 30 * 24 * 60 * 60 * 1000);
 
-    const receitaRealizadaResult = (await this.pagamentoModel.findOne({
-      attributes: [[fn('SUM', col('debito.valor')), 'total']],
-      include: [{ model: Debito, where: { status: 'pago' }, attributes: [] }],
-      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-      raw: true,
-    })) as ResultadoReceita | null;
-
-    const receitaPendente = await this.debitoModel.sum('valor', {
-      where: { status: 'pendente' },
-    });
-
-    const receitaTaxa = await this.pagamentoModel.sum('taxa', {
-      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-    });
-
-    const ticketMedioResult = (await this.pagamentoModel.findOne({
-      attributes: [[fn('AVG', col('valor_total')), 'media']],
-      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-      raw: true,
-    })) as ResultadoTicketMedio | null;
-
-    const historicoMensalResult = (await this.pagamentoModel.findAll({
-      attributes: [
-        [fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'mes'],
-        [fn('SUM', col('valor_total')), 'receitaRealizada'],
-      ],
-      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-      group: [fn('DATE_FORMAT', col('created_at'), '%Y-%m')],
-      order: [[fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'ASC']],
-      raw: true,
-    })) as unknown as ResultadoHistoricoMensal[];
-
-    const inadimplenciaResult = (await this.parcelaModel.findOne({
-      attributes: [
-        [fn('SUM', col('valor')), 'valorTotal'],
-        [literal('COUNT(DISTINCT id_pagamento)'), 'quantidadePagamentos'],
-        [fn('COUNT', col('id')), 'quantidadeParcelas'],
-      ],
-      where: {
-        vencimento: { [Op.lt]: hoje },
-        status: { [Op.ne]: 'pago' },
-      },
-      raw: true,
-    })) as ResultadoInadimplencia | null;
-
-    const previsaoCaixaResult = (await this.parcelaModel.findOne({
-      attributes: [
-        [fn('SUM', col('valor')), 'valorTotal'],
-        [fn('COUNT', col('id')), 'quantidadeParcelas'],
-      ],
-      where: {
-        vencimento: { [Op.between]: [hoje, em30Dias] },
-        status: { [Op.ne]: 'pago' },
-      },
-      raw: true,
-    })) as ResultadoPrevisaoCaixa | null;
-
-    const porMetodoResult = (await this.pagamentoModel.findAll({
-      attributes: [
-        ['metodo_pagamento', 'metodo'],
-        [fn('COUNT', col('id')), 'quantidade'],
-        [fn('SUM', col('valor_total')), 'valorTotal'],
-      ],
-      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-      group: ['metodo_pagamento'],
-      raw: true,
-    })) as unknown as ResultadoDistribuicaoMetodo[];
-
-    const porTipoResult = (await this.pagamentoModel.findAll({
-      attributes: [
-        ['tipo_pagamento', 'tipo'],
-        [fn('COUNT', col('id')), 'quantidade'],
-        [fn('SUM', col('valor_total')), 'valorTotal'],
-      ],
-      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-      group: ['tipo_pagamento'],
-      raw: true,
-    })) as unknown as ResultadoDistribuicaoTipo[];
+    const [
+      receitaRealizadaResult,
+      receitaPendente,
+      receitaTaxa,
+      ticketMedioResult,
+      historicoMensalResult,
+      inadimplenciaResult,
+      previsaoCaixaResult,
+      porMetodoResult,
+      porTipoResult,
+    ] = await Promise.all([
+      this.pagamentoModel.findOne({
+        attributes: [[fn('SUM', col('debito.valor')), 'total']],
+        include: [{ model: Debito, where: { status: 'pago' }, attributes: [] }],
+        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+        raw: true,
+      }) as Promise<ResultadoReceita | null>,
+      this.debitoModel.sum('valor', {
+        where: { status: 'pendente' },
+      }),
+      this.pagamentoModel.sum('taxa', {
+        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+      }),
+      this.pagamentoModel.findOne({
+        attributes: [[fn('AVG', col('valor_total')), 'media']],
+        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+        raw: true,
+      }) as Promise<ResultadoTicketMedio | null>,
+      this.pagamentoModel.findAll({
+        attributes: [
+          [fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'mes'],
+          [fn('SUM', col('valor_total')), 'receitaRealizada'],
+        ],
+        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+        group: [fn('DATE_FORMAT', col('created_at'), '%Y-%m')],
+        order: [[fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'ASC']],
+        raw: true,
+      }) as unknown as Promise<ResultadoHistoricoMensal[]>,
+      this.parcelaModel.findOne({
+        attributes: [
+          [fn('SUM', col('valor')), 'valorTotal'],
+          [literal('COUNT(DISTINCT id_pagamento)'), 'quantidadePagamentos'],
+          [fn('COUNT', col('id')), 'quantidadeParcelas'],
+        ],
+        where: {
+          vencimento: { [Op.lt]: hoje },
+          status: { [Op.ne]: 'pago' },
+        },
+        raw: true,
+      }) as Promise<ResultadoInadimplencia | null>,
+      this.parcelaModel.findOne({
+        attributes: [
+          [fn('SUM', col('valor')), 'valorTotal'],
+          [fn('COUNT', col('id')), 'quantidadeParcelas'],
+        ],
+        where: {
+          vencimento: { [Op.between]: [hoje, em30Dias] },
+          status: { [Op.ne]: 'pago' },
+        },
+        raw: true,
+      }) as Promise<ResultadoPrevisaoCaixa | null>,
+      this.pagamentoModel.findAll({
+        attributes: [
+          ['metodo_pagamento', 'metodo'],
+          [fn('COUNT', col('id')), 'quantidade'],
+          [fn('SUM', col('valor_total')), 'valorTotal'],
+        ],
+        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+        group: ['metodo_pagamento'],
+        raw: true,
+      }) as unknown as Promise<ResultadoDistribuicaoMetodo[]>,
+      this.pagamentoModel.findAll({
+        attributes: [
+          ['tipo_pagamento', 'tipo'],
+          [fn('COUNT', col('id')), 'quantidade'],
+          [fn('SUM', col('valor_total')), 'valorTotal'],
+        ],
+        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+        group: ['tipo_pagamento'],
+        raw: true,
+      }) as unknown as Promise<ResultadoDistribuicaoTipo[]>,
+    ]);
 
     // ─── Processamento dos dados financeiros ─────────────────────────────────
 
@@ -658,7 +679,6 @@ export class DashboardService {
     inicioParam?: string,
     fimParam?: string,
   ): Promise<DashboardReturnDto> {
-
     const [geral, solicitacoes, veiculos, servicos, financeiro] =
       await Promise.all([
         this.obterDadosGerais(inicioParam, fimParam),

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -12,7 +12,14 @@ import { Usuario } from 'src/models/usuario.model';
 import { Veiculo } from 'src/models/veiculo.model';
 import { DebitoVeiculo } from 'src/models/debito-veiculo.model';
 
-import { DashboardReturnDto } from './dto/dashboard-return.dto';
+import {
+  DashboardReturnDto,
+  GeralDto,
+  SolicitacoesDto,
+  VeiculosDto,
+  ServicosDto,
+  FinanceiroDto,
+} from './dto/dashboard-return.dto';
 import type { ModelCtor } from 'sequelize-typescript';
 import type {
   ResultadoReceita,
@@ -29,6 +36,19 @@ import {
   StatusCountRow,
   TempoConclusaoRow,
 } from './dashboard.types';
+
+// Interface auxiliar para o retorno de obterDadosGerais
+interface DadosGeraisComStatus extends GeralDto {
+  porStatus: {
+    recebido: number;
+    emAndamento: number;
+    aguardandoPagamento: number;
+    aguardandoDocumento: number;
+    concluido: number;
+    cancelado: number;
+  };
+  statusAbertos: string[];
+}
 
 @Injectable()
 export class DashboardService {
@@ -72,20 +92,12 @@ export class DashboardService {
     return meses;
   }
 
-  async retornarInfosDashboard(
-    inicioParam?: string,
-    fimParam?: string,
-  ): Promise<DashboardReturnDto> {
-    const dataFim = fimParam ? new Date(fimParam) : new Date();
-    dataFim.setHours(23, 59, 59, 999);
-
-    const dataInicio = inicioParam
-      ? new Date(inicioParam)
-      : new Date(new Date(dataFim).setMonth(new Date(dataFim).getMonth() - 6));
-    dataInicio.setHours(0, 0, 0, 0);
-
+  /** Retorna dados gerais: solicitações, documentos, clientes e débitos do período */
+  private async obterDadosGerais(
+    dataInicio: Date,
+    dataFim: Date,
+  ): Promise<DadosGeraisComStatus> {
     const hoje = new Date();
-    const em30Dias = new Date(hoje.getTime() + 30 * 24 * 60 * 60 * 1000);
 
     const statusAbertos = [
       'recebido',
@@ -94,355 +106,56 @@ export class DashboardService {
       'em_andamento',
     ];
 
-    // ─── Query de solicitações ────────────────────────────────────────────────
+    const porStatusRaw = (await this.solicitacaoModel.findAll({
+      attributes: [
+        'status',
+        [fn('COUNT', col('Solicitacao.id')), 'quantidade'],
+      ],
+      where: {
+        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+      },
+      group: [col('Solicitacao.status')],
+      raw: true,
+    })) as unknown as any[];
 
-    const solicitacoesQuery = Promise.all([
-      this.solicitacaoModel.findAll({
-        attributes: [
-          'status',
-          [fn('COUNT', col('Solicitacao.id')), 'quantidade'],
-        ],
-        where: {
-          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
-        },
-        group: [col('Solicitacao.status')],
-        raw: true,
-      }) as unknown as Promise<StatusCountRow[]>,
-
-      this.solicitacaoModel.count({
-        include: [{ model: Servico, attributes: [], required: true }],
-        where: {
-          status: { [Op.in]: statusAbertos },
-          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
-          [Op.and]: [
-            literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
-            literal(`
-              DATEDIFF(NOW(), \`Solicitacao\`.\`data_solicitacao\`)
-              BETWEEN GREATEST(\`servico\`.\`prazo_estimado_dias\` - ${this.DIAS_ALERTA_VENCIMENTO}, 0)
-              AND \`servico\`.\`prazo_estimado_dias\`
-            `),
-          ],
-        },
-      }),
-
-      this.solicitacaoModel.findAll({
-        attributes: [
-          [col('Solicitacao.servico_id'), 'servicoId'],
-          [col('servico.nome'), 'servicoNome'],
-          [col('servico.prazo_estimado_dias'), 'prazoEstimadoDias'],
-          [
-            fn(
-              'AVG',
-              literal(
-                'DATEDIFF(`Solicitacao`.`data_conclusao`, `Solicitacao`.`data_solicitacao`)',
-              ),
-            ),
-            'mediaRealDias',
-          ],
-          [fn('COUNT', col('Solicitacao.id')), 'totalConcluidas'],
-        ],
-        include: [{ model: Servico, attributes: [], required: true }],
-        where: {
-          status: 'concluido',
-          dataConclusao: { [Op.between]: [dataInicio, dataFim] },
-          [Op.and]: [literal('`servico`.`prazo_estimado_dias` IS NOT NULL')],
-        },
-        group: [
-          col('Solicitacao.servico_id'),
-          col('servico.id'),
-          col('servico.nome'),
-          col('servico.prazo_estimado_dias'),
-        ],
-        order: [[literal('mediaRealDias'), 'DESC']],
-        raw: true,
-      }) as unknown as Promise<TempoConclusaoRow[]>,
-
-      this.solicitacaoModel.count({
-        include: [{ model: Servico, attributes: [], required: true }],
-        where: {
-          status: 'concluido',
-          dataConclusao: { [Op.between]: [dataInicio, dataFim] },
-          [Op.and]: [
-            literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
-            literal(`
-              DATEDIFF(\`Solicitacao\`.\`data_conclusao\`, \`Solicitacao\`.\`data_solicitacao\`)
-              > \`servico\`.\`prazo_estimado_dias\`
-            `),
-          ],
-        },
-      }),
-
-      this.solicitacaoModel.count({
-        where: { status: 'concluido' },
-      }),
-
-      this.documentoSolicitacaoModel.count({
+    const documentosPendentesValidacao =
+      await this.documentoSolicitacaoModel.count({
         where: { statusValidacao: 'pendente' },
-      }),
+      });
 
-      this.usuarioModel.count({
-        where: {
-          nivel: 'cliente',
-          dataCadastro: { [Op.between]: [dataInicio, dataFim] },
-        },
-      }),
+    const clientesNovosMesAtual = await this.usuarioModel.count({
+      where: {
+        nivel: 'cliente',
+        dataCadastro: { [Op.between]: [dataInicio, dataFim] },
+      },
+    });
 
-      this.solicitacaoModel.count({
-        where: {
-          status: 'concluido',
-          dataConclusao: { [Op.between]: [dataInicio, dataFim] },
-        },
-      }),
+    const solicitacoesConcluidas = await this.solicitacaoModel.count({
+      where: {
+        status: 'concluido',
+        dataConclusao: { [Op.between]: [dataInicio, dataFim] },
+      },
+    });
 
-      this.servicoModel.count({
-        where: { ativo: true },
-      }),
+    const debitosEmAbertoQuantidade = await this.debitoModel.count({
+      where: { status: 'pendente' },
+    });
 
-      this.servicoModel.count({
-        where: { [Op.or]: [{ ativo: false }, { ativo: null }] },
-      }),
+    const debitosEmAbertoValor = await this.debitoModel.sum('valor', {
+      where: { status: 'pendente' },
+    });
 
-      this.solicitacaoModel.findAll({
-        attributes: [
-          [col('Solicitacao.servico_id'), 'servicoId'],
-          [fn('COUNT', col('Solicitacao.id')), 'totalSolicitacoes'],
-        ],
-        include: [
-          { model: Servico, attributes: ['id', 'nome'], as: 'servico' },
-        ],
-        where: {
-          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
-        },
-        group: ['servico.id', 'Solicitacao.servico_id'],
-        order: [[literal('totalSolicitacoes'), 'DESC']],
-        limit: 5,
-      }),
-
-      this.debitoServicoModel.findAll({
-        attributes: [
-          [col('DebitoServico.id_servico'), 'servicoId'],
-          [fn('COUNT', col('DebitoServico.id')), 'totalSolicitacoes'],
-          [fn('SUM', col('debito.valor')), 'receitaTotal'],
-        ],
-        include: [
-          { model: Servico, attributes: ['id', 'nome'], as: 'servico' },
-          {
-            model: Debito,
-            attributes: [],
-            as: 'debito',
-            where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-          },
-        ],
-        group: ['servico.id', 'DebitoServico.id_servico'],
-        order: [[literal('receitaTotal'), 'DESC']],
-        limit: 5,
-      }),
-    ]);
-
-    // Queries veiculos
-
-    const [
-      totalVeiculosCadastrados,
-      veiculosComSolicitacaoAtiva,
-      debitosPendentesResult,
-    ] = await Promise.all([
-      // Total de veículos cadastrados
-      this.veiculoModel.count(),
-
-      // Veículos com solicitação ativa
-      this.solicitacaoModel.count({
-        where: {
-          veiculoId: { [Op.ne]: null },
-          status: {
-            [Op.in]: [
-              'recebido',
-              'aguardando_pagamento',
-              'aguardando_documento',
-              'em_andamento',
-            ],
-          },
-        },
-        distinct: true,
-        col: 'veiculo_id',
-      }),
-
-      // Débitos pendentes por veículo
-      this.debitoVeiculoModel.findAll({
-        include: [
-          {
-            model: Debito,
-            where: { status: 'pendente' },
-            attributes: [],
-          },
-          {
-            model: Veiculo,
-            attributes: ['id', 'placa'],
-          },
-        ],
-        attributes: [
-          'idVeiculo',
-          [fn('COUNT', col('DebitoVeiculo.id')), 'totalDebitos'],
-          [fn('SUM', col('debito.valor')), 'valorTotal'],
-        ],
-        group: ['idVeiculo', 'veiculo.id'],
-        raw: true,
-        nest: true,
-      }),
-    ]);
-
-    // ─── Query financeira ────────────────────────────────────────────────────
-
-    const financeiroQuery: Promise<
-      [
-        ResultadoReceita | null,
-        number,
-        number,
-        number,
-        ResultadoTicketMedio | null,
-        ResultadoHistoricoMensal[],
-        ResultadoInadimplencia | null,
-        ResultadoPrevisaoCaixa | null,
-        ResultadoDistribuicaoMetodo[],
-        ResultadoDistribuicaoTipo[],
-      ]
-    > = Promise.all([
-      this.pagamentoModel.findOne({
-        attributes: [[fn('SUM', col('debito.valor')), 'total']],
-        include: [{ model: Debito, where: { status: 'pago' }, attributes: [] }],
-        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-        raw: true,
-      }) as unknown as Promise<ResultadoReceita | null>,
-
-      this.debitoModel.sum('valor', {
-        where: { status: 'pendente' },
-      }),
-
-      this.debitoModel.count({
-        where: { status: 'pendente' },
-      }),
-
-      this.pagamentoModel.sum('taxa', {
-        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-      }),
-
-      this.pagamentoModel.findOne({
-        attributes: [[fn('AVG', col('valor_total')), 'media']],
-        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-        raw: true,
-      }) as unknown as Promise<ResultadoTicketMedio | null>,
-
-      this.pagamentoModel.findAll({
-        attributes: [
-          [fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'mes'],
-          [fn('SUM', col('valor_total')), 'receitaRealizada'],
-        ],
-        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-        group: [fn('DATE_FORMAT', col('created_at'), '%Y-%m')],
-        order: [[fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'ASC']],
-        raw: true,
-      }) as unknown as Promise<ResultadoHistoricoMensal[]>,
-
-      this.parcelaModel.findOne({
-        attributes: [
-          [fn('SUM', col('valor')), 'valorTotal'],
-          [literal('COUNT(DISTINCT id_pagamento)'), 'quantidadePagamentos'],
-          [fn('COUNT', col('id')), 'quantidadeParcelas'],
-        ],
-        where: {
-          vencimento: { [Op.lt]: hoje },
-          status: { [Op.ne]: 'pago' },
-        },
-        raw: true,
-      }) as unknown as Promise<ResultadoInadimplencia | null>,
-
-      this.parcelaModel.findOne({
-        attributes: [
-          [fn('SUM', col('valor')), 'valorTotal'],
-          [fn('COUNT', col('id')), 'quantidadeParcelas'],
-        ],
-        where: {
-          vencimento: { [Op.between]: [hoje, em30Dias] },
-          status: { [Op.ne]: 'pago' },
-        },
-        raw: true,
-      }) as unknown as Promise<ResultadoPrevisaoCaixa | null>,
-
-      this.pagamentoModel.findAll({
-        attributes: [
-          ['metodo_pagamento', 'metodo'],
-          [fn('COUNT', col('id')), 'quantidade'],
-          [fn('SUM', col('valor_total')), 'valorTotal'],
-        ],
-        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-        group: ['metodo_pagamento'],
-        raw: true,
-      }) as unknown as Promise<ResultadoDistribuicaoMetodo[]>,
-
-      this.pagamentoModel.findAll({
-        attributes: [
-          ['tipo_pagamento', 'tipo'],
-          [fn('COUNT', col('id')), 'quantidade'],
-          [fn('SUM', col('valor_total')), 'valorTotal'],
-        ],
-        where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
-        group: ['tipo_pagamento'],
-        raw: true,
-      }) as unknown as Promise<ResultadoDistribuicaoTipo[]>,
-    ]);
-
-    interface DebitoVeiculoRaw {
-      idVeiculo: number;
-      totalDebitos: string;
-      valorTotal: string;
-      veiculo: { placa: string };
-    }
-
-    const porVeiculo = (
-      debitosPendentesResult as unknown as DebitoVeiculoRaw[]
-    ).map((item) => ({
-      veiculoId: item.idVeiculo,
-      placa: item.veiculo.placa,
-      totalDebitos: Number(item.totalDebitos),
-      valorTotal: Number(item.valorTotal),
-    }));
-
-    const valorTotalGeral = porVeiculo.reduce(
-      (acc, item) => acc + item.valorTotal,
-      0,
-    );
-
-    // ─── Execução paralela e desestruturação ─────────────────────────────────
-
-    const [
-      [
-        porStatusRaw,
-        proximasDeVencerQuantidade,
-        tempoConclusaoPorServicoRaw,
-        foraDoPrazoQuantidade,
-        totalConcluidas,
-        documentosPendentesValidacao,
-        clientesNovosMesAtual,
-        solicitacoesConcluidas,
-        servicosAtivos,
-        servicosPausados,
-        maisSolicitadosRaw,
-        receitaPorServicoRaw,
+    const parcelasVencidasResult = (await this.parcelaModel.findOne({
+      attributes: [
+        [fn('SUM', col('valor')), 'valorTotal'],
+        [fn('COUNT', col('id')), 'quantidadeParcelas'],
       ],
-      [
-        receitaRealizadaResult,
-        receitaPendenteRaw,
-        debitosEmAbertoQuantidade,
-        receitaTaxaRaw,
-        ticketMedioResult,
-        historicoMensalResult,
-        inadimplenciaResult,
-        previsaoCaixaResult,
-        porMetodoResult,
-        porTipoResult,
-      ],
-    ] = await Promise.all([solicitacoesQuery, financeiroQuery]);
-
-    // ─── Processamento: solicitações ─────────────────────────────────────────
+      where: {
+        vencimento: { [Op.lt]: hoje },
+        status: { [Op.ne]: 'pago' },
+      },
+      raw: true,
+    })) as any;
 
     const porStatusBase = {
       recebido: 0,
@@ -455,7 +168,6 @@ export class DashboardService {
 
     const porStatus = porStatusRaw.reduce((acc, item) => {
       const quantidade = Number(item.quantidade ?? 0);
-
       if (item.status === 'recebido') acc.recebido = quantidade;
       if (item.status === 'em_andamento') acc.emAndamento = quantidade;
       if (item.status === 'aguardando_pagamento')
@@ -464,7 +176,6 @@ export class DashboardService {
         acc.aguardandoDocumento = quantidade;
       if (item.status === 'concluido') acc.concluido = quantidade;
       if (item.status === 'cancelado') acc.cancelado = quantidade;
-
       return acc;
     }, porStatusBase);
 
@@ -474,13 +185,9 @@ export class DashboardService {
       porStatus.aguardandoPagamento +
       porStatus.aguardandoDocumento;
 
-    const totalSolicitacoesPeriodo =
-      porStatus.recebido +
-      porStatus.emAndamento +
-      porStatus.aguardandoPagamento +
-      porStatus.aguardandoDocumento +
-      porStatus.concluido +
-      porStatus.cancelado;
+    const totalSolicitacoesPeriodo: number = (
+      Object.values(porStatus) as number[]
+    ).reduce((a: number, b: number) => a + b, 0);
 
     const taxaCancelamentoPct =
       totalSolicitacoesPeriodo > 0
@@ -489,44 +196,266 @@ export class DashboardService {
           )
         : 0;
 
-    const tempoConclusaoPorServico = tempoConclusaoPorServicoRaw.map(
-      (item) => ({
-        servicoId: Number(item.servicoId),
-        servicoNome: item.servicoNome,
-        prazoEstimadoDias: Number(item.prazoEstimadoDias),
-        mediaRealDias: Number(Number(item.mediaRealDias).toFixed(2)),
-        totalConcluidas: Number(item.totalConcluidas),
-      }),
-    );
+    return {
+      solicitacoesEmAberto,
+      solicitacoesConcluidas,
+      documentosPendentesValidacao,
+      clientesNovosMesAtual,
+      taxaCancelamentoPct,
+      debitosEmAberto: {
+        quantidade: Number(debitosEmAbertoQuantidade ?? 0),
+        valorTotal: Number(debitosEmAbertoValor ?? 0),
+      },
+      parcelasVencidasNaoPagas: {
+        quantidade: Number(parcelasVencidasResult?.quantidadeParcelas ?? 0),
+        valorTotal: Number(parcelasVencidasResult?.valorTotal ?? 0),
+      },
+      porStatus,
+      statusAbertos,
+    };
+  }
+
+  /** Retorna dados de solicitações: status, prazos, tempo de conclusão */
+  private async obterDadosSolicitacoes(
+    dataInicio: Date,
+    dataFim: Date,
+    porStatus: any,
+    statusAbertos: string[],
+  ): Promise<SolicitacoesDto> {
+    const proximasDeVencer = await this.solicitacaoModel.count({
+      include: [{ model: Servico, attributes: [], required: true }],
+      where: {
+        status: { [Op.in]: statusAbertos },
+        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+        [Op.and]: [
+          literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
+          literal(`
+            DATEDIFF(NOW(), \`Solicitacao\`.\`data_solicitacao\`)
+            BETWEEN GREATEST(\`servico\`.\`prazo_estimado_dias\` - ${this.DIAS_ALERTA_VENCIMENTO}, 0)
+            AND \`servico\`.\`prazo_estimado_dias\`
+          `),
+        ],
+      },
+    });
+
+    const tempoConclusaoRaw = (await this.solicitacaoModel.findAll({
+      attributes: [
+        [col('Solicitacao.servico_id'), 'servicoId'],
+        [col('servico.nome'), 'servicoNome'],
+        [col('servico.prazo_estimado_dias'), 'prazoEstimadoDias'],
+        [
+          fn(
+            'AVG',
+            literal(
+              'DATEDIFF(`Solicitacao`.`data_conclusao`, `Solicitacao`.`data_solicitacao`)',
+            ),
+          ),
+          'mediaRealDias',
+        ],
+        [fn('COUNT', col('Solicitacao.id')), 'totalConcluidas'],
+      ],
+      include: [{ model: Servico, attributes: [], required: true }],
+      where: {
+        status: 'concluido',
+        dataConclusao: { [Op.between]: [dataInicio, dataFim] },
+        [Op.and]: [literal('`servico`.`prazo_estimado_dias` IS NOT NULL')],
+      },
+      group: [
+        col('Solicitacao.servico_id'),
+        col('servico.id'),
+        col('servico.nome'),
+        col('servico.prazo_estimado_dias'),
+      ],
+      order: [[literal('mediaRealDias'), 'DESC']],
+      raw: true,
+    })) as unknown as any[];
+
+    const foraDoPrazoQuantidade = await this.solicitacaoModel.count({
+      include: [{ model: Servico, attributes: [], required: true }],
+      where: {
+        status: 'concluido',
+        dataConclusao: { [Op.between]: [dataInicio, dataFim] },
+        [Op.and]: [
+          literal('`servico`.`prazo_estimado_dias` IS NOT NULL'),
+          literal(`
+            DATEDIFF(\`Solicitacao\`.\`data_conclusao\`, \`Solicitacao\`.\`data_solicitacao\`)
+            > \`servico\`.\`prazo_estimado_dias\`
+          `),
+        ],
+      },
+    });
+
+    const totalConcluidas = await this.solicitacaoModel.count({
+      where: { status: 'concluido' },
+    });
+
+    const tempoConclusaoPorServico = tempoConclusaoRaw.map((item) => ({
+      servicoId: Number(item.servicoId),
+      servicoNome: item.servicoNome,
+      prazoEstimadoDias: Number(item.prazoEstimadoDias),
+      mediaRealDias: Number(Number(item.mediaRealDias).toFixed(2)),
+      totalConcluidas: Number(item.totalConcluidas),
+    }));
 
     const percentual =
       totalConcluidas > 0
         ? Number(((foraDoPrazoQuantidade / totalConcluidas) * 100).toFixed(2))
         : 0;
 
-    const maisSolicitados = (
-      maisSolicitadosRaw as unknown as MaisSolicitadosRow[]
-    ).map((item) => ({
-      servicoId: Number(item.get('servicoId') ?? 0),
-      nome: item.servico?.nome ?? '',
-      totalSolicitacoes: Number(item.get('totalSolicitacoes') ?? 0),
-    }));
+    return {
+      porStatus,
+      proximasDeVencer: { quantidade: proximasDeVencer },
+      tempoConclusaoPorServico,
+      foraDoPrazo: {
+        quantidade: foraDoPrazoQuantidade,
+        totalConcluidas,
+        percentual,
+      },
+    };
+  }
+
+  /** Retorna dados de veículos: cadastrados, com solicitações ativas e débitos pendentes */
+  private async obterDadosVeiculos(): Promise<VeiculosDto> {
+    const totalVeiculosCadastrados = await this.veiculoModel.count();
+
+    const veiculosComSolicitacaoAtiva = await this.solicitacaoModel.count({
+      where: {
+        veiculoId: { [Op.ne]: null },
+        status: {
+          [Op.in]: [
+            'recebido',
+            'aguardando_pagamento',
+            'aguardando_documento',
+            'em_andamento',
+          ],
+        },
+      },
+      distinct: true,
+      col: 'veiculo_id',
+    });
+
+    const debitosPendentesResult = (await this.debitoVeiculoModel.findAll({
+      include: [
+        {
+          model: Debito,
+          where: { status: 'pendente' },
+          attributes: [],
+        },
+        {
+          model: Veiculo,
+          attributes: ['id', 'placa'],
+        },
+      ],
+      attributes: [
+        'idVeiculo',
+        [fn('COUNT', col('DebitoVeiculo.id')), 'totalDebitos'],
+        [fn('SUM', col('debito.valor')), 'valorTotal'],
+      ],
+      group: ['idVeiculo', 'veiculo.id'],
+      raw: true,
+      nest: true,
+    })) as unknown as any[];
+
+    interface DebitoVeiculoRaw {
+      idVeiculo: number;
+      totalDebitos: string;
+      valorTotal: string;
+      veiculo: { placa: string };
+    }
+
+    const porVeiculo = (debitosPendentesResult as DebitoVeiculoRaw[]).map(
+      (item) => ({
+        veiculoId: item.idVeiculo,
+        placa: item.veiculo.placa,
+        totalDebitos: Number(item.totalDebitos),
+        valorTotal: Number(item.valorTotal),
+      }),
+    );
+
+    const valorTotalGeral = porVeiculo.reduce(
+      (acc, item) => acc + item.valorTotal,
+      0,
+    );
+
+    return {
+      totalCadastrados: totalVeiculosCadastrados,
+      comSolicitacaoAtiva: veiculosComSolicitacaoAtiva,
+      comDebitoPendente: porVeiculo.length,
+      debitosPendentes: {
+        valorTotal: valorTotalGeral,
+        porVeiculo,
+      },
+    };
+  }
+
+  /** Retorna dados de serviços: ativos, pausados e receita por serviço */
+  private async obterDadosServicos(
+    dataInicio: Date,
+    dataFim: Date,
+  ): Promise<ServicosDto> {
+    const servicosAtivos = await this.servicoModel.count({
+      where: { ativo: true },
+    });
+
+    const servicosPausados = await this.servicoModel.count({
+      where: { [Op.or]: [{ ativo: false }, { ativo: null }] },
+    });
+
+    const maisSolicitadosRaw = (await this.solicitacaoModel.findAll({
+      attributes: [
+        [col('Solicitacao.servico_id'), 'servicoId'],
+        [fn('COUNT', col('Solicitacao.id')), 'totalSolicitacoes'],
+      ],
+      include: [{ model: Servico, attributes: ['id', 'nome'], as: 'servico' }],
+      where: {
+        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+      },
+      group: ['servico.id', 'Solicitacao.servico_id'],
+      order: [[literal('totalSolicitacoes'), 'DESC']],
+      limit: 5,
+    })) as unknown as any[];
+
+    const receitaPorServicoRaw = (await this.debitoServicoModel.findAll({
+      attributes: [
+        [col('DebitoServico.id_servico'), 'servicoId'],
+        [fn('COUNT', col('DebitoServico.id')), 'totalSolicitacoes'],
+        [fn('SUM', col('debito.valor')), 'receitaTotal'],
+      ],
+      include: [
+        { model: Servico, attributes: ['id', 'nome'], as: 'servico' },
+        {
+          model: Debito,
+          attributes: [],
+          as: 'debito',
+          where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+        },
+      ],
+      group: ['servico.id', 'DebitoServico.id_servico'],
+      order: [[literal('receitaTotal'), 'DESC']],
+      limit: 5,
+    })) as unknown as any[];
+
+    const todosServicos = await this.servicoModel.findAll({
+      where: { ativo: true },
+      attributes: ['id', 'nome'],
+    });
+
+    const maisSolicitados = (maisSolicitadosRaw as MaisSolicitadosRow[]).map(
+      (item) => ({
+        servicoId: Number(item.get('servicoId') ?? 0),
+        nome: item.servico?.nome ?? '',
+        totalSolicitacoes: Number(item.get('totalSolicitacoes') ?? 0),
+      }),
+    );
 
     const receitaPorServico = (
-      receitaPorServicoRaw as unknown as ReceitaPorServicoRow[]
+      receitaPorServicoRaw as ReceitaPorServicoRow[]
     ).map((item) => ({
       servicoId: Number(item.get('servicoId') ?? 0),
       nome: item.servico?.nome ?? '',
       totalSolicitacoes: Number(item.get('totalSolicitacoes') ?? 0),
       receitaTotal: Number(item.get('receitaTotal') ?? 0),
     }));
-
-    // ─── Processamento: serviços ─────────────────────────────────────────────
-
-    const todosServicos = await this.servicoModel.findAll({
-      where: { ativo: true },
-      attributes: ['id', 'nome'],
-    });
 
     const receitaMap = new Map(receitaPorServico.map((r) => [r.servicoId, r]));
 
@@ -540,15 +469,109 @@ export class DashboardService {
       };
     });
 
-    // ─── Processamento: financeiro ───────────────────────────────────────────
+    return {
+      ativos: servicosAtivos,
+      pausados: servicosPausados,
+      maisSolicitados,
+      receitaPorServicoCompleto,
+    };
+  }
+
+  /** Retorna dados financeiros: receita, débitos, parcelas, histórico mensal e distribuição de pagamentos */
+  private async obterDadosFinanceiro(
+    dataInicio: Date,
+    dataFim: Date,
+  ): Promise<FinanceiroDto> {
+    const hoje = new Date();
+    const em30Dias = new Date(hoje.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    const receitaRealizadaResult = (await this.pagamentoModel.findOne({
+      attributes: [[fn('SUM', col('debito.valor')), 'total']],
+      include: [{ model: Debito, where: { status: 'pago' }, attributes: [] }],
+      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+      raw: true,
+    })) as any;
+
+    const receitaPendente = await this.debitoModel.sum('valor', {
+      where: { status: 'pendente' },
+    });
+
+    const receitaTaxa = await this.pagamentoModel.sum('taxa', {
+      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+    });
+
+    const ticketMedioResult = (await this.pagamentoModel.findOne({
+      attributes: [[fn('AVG', col('valor_total')), 'media']],
+      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+      raw: true,
+    })) as any;
+
+    const historicoMensalResult = (await this.pagamentoModel.findAll({
+      attributes: [
+        [fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'mes'],
+        [fn('SUM', col('valor_total')), 'receitaRealizada'],
+      ],
+      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+      group: [fn('DATE_FORMAT', col('created_at'), '%Y-%m')],
+      order: [[fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'ASC']],
+      raw: true,
+    })) as any[];
+
+    const inadimplenciaResult = (await this.parcelaModel.findOne({
+      attributes: [
+        [fn('SUM', col('valor')), 'valorTotal'],
+        [literal('COUNT(DISTINCT id_pagamento)'), 'quantidadePagamentos'],
+        [fn('COUNT', col('id')), 'quantidadeParcelas'],
+      ],
+      where: {
+        vencimento: { [Op.lt]: hoje },
+        status: { [Op.ne]: 'pago' },
+      },
+      raw: true,
+    })) as any;
+
+    const previsaoCaixaResult = (await this.parcelaModel.findOne({
+      attributes: [
+        [fn('SUM', col('valor')), 'valorTotal'],
+        [fn('COUNT', col('id')), 'quantidadeParcelas'],
+      ],
+      where: {
+        vencimento: { [Op.between]: [hoje, em30Dias] },
+        status: { [Op.ne]: 'pago' },
+      },
+      raw: true,
+    })) as any;
+
+    const porMetodoResult = (await this.pagamentoModel.findAll({
+      attributes: [
+        ['metodo_pagamento', 'metodo'],
+        [fn('COUNT', col('id')), 'quantidade'],
+        [fn('SUM', col('valor_total')), 'valorTotal'],
+      ],
+      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+      group: ['metodo_pagamento'],
+      raw: true,
+    })) as any[];
+
+    const porTipoResult = (await this.pagamentoModel.findAll({
+      attributes: [
+        ['tipo_pagamento', 'tipo'],
+        [fn('COUNT', col('id')), 'quantidade'],
+        [fn('SUM', col('valor_total')), 'valorTotal'],
+      ],
+      where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
+      group: ['tipo_pagamento'],
+      raw: true,
+    })) as any[];
+
+    // ─── Processamento dos dados financeiros ─────────────────────────────────
 
     const receitaRealizada = Number(receitaRealizadaResult?.total ?? 0);
-    const receitaPendente = Number(receitaPendenteRaw ?? 0);
-    const receitaTaxa = Number(receitaTaxaRaw ?? 0);
+    const receitaPendenteNum = Number(receitaPendente ?? 0);
+    const receitaTaxaNum = Number(receitaTaxa ?? 0);
     const ticketMedio = Number(ticketMedioResult?.media ?? 0);
 
     const mesesPeriodo = this.gerarMesesNoPeriodo(dataInicio, dataFim);
-
     const mapaHistorico = new Map<string, number>(
       historicoMensalResult.map((m: ResultadoHistoricoMensal) => [
         m.mes,
@@ -570,29 +593,6 @@ export class DashboardService {
         ? Number((somaHistorico / mesesPeriodo.length).toFixed(2))
         : 0;
 
-    const inadimplencia = {
-      valorTotal: Number(inadimplenciaResult?.valorTotal ?? 0),
-      quantidadePagamentos: Number(
-        inadimplenciaResult?.quantidadePagamentos ?? 0,
-      ),
-      quantidadeParcelas: Number(inadimplenciaResult?.quantidadeParcelas ?? 0),
-    };
-
-    const previsaoCaixa30Dias = {
-      valorTotal: Number(previsaoCaixaResult?.valorTotal ?? 0),
-      quantidadeParcelas: Number(previsaoCaixaResult?.quantidadeParcelas ?? 0),
-    };
-
-    const debitosEmAberto = {
-      quantidade: Number(debitosEmAbertoQuantidade ?? 0),
-      valorTotal: Number(receitaPendenteRaw ?? 0),
-    };
-
-    const parcelasVencidasNaoPagas = {
-      quantidade: Number(inadimplenciaResult?.quantidadeParcelas ?? 0),
-      valorTotal: Number(inadimplenciaResult?.valorTotal ?? 0),
-    };
-
     const porMetodoPagamento = porMetodoResult.map(
       (m: ResultadoDistribuicaoMetodo) => ({
         metodo: m.metodo,
@@ -609,57 +609,80 @@ export class DashboardService {
       }),
     );
 
-    // ─── Retorno ─────────────────────────────────────────────────────────────
+    return {
+      receitaRealizada,
+      receitaPendente: receitaPendenteNum,
+      receitaTaxa: receitaTaxaNum,
+      ticketMedio,
+      mediaMensalReceita,
+      historicoMensal,
+      inadimplencia: {
+        valorTotal: Number(inadimplenciaResult?.valorTotal ?? 0),
+        quantidadePagamentos: Number(
+          inadimplenciaResult?.quantidadePagamentos ?? 0,
+        ),
+        quantidadeParcelas: Number(
+          inadimplenciaResult?.quantidadeParcelas ?? 0,
+        ),
+      },
+      previsaoCaixa30Dias: {
+        valorTotal: Number(previsaoCaixaResult?.valorTotal ?? 0),
+        quantidadeParcelas: Number(
+          previsaoCaixaResult?.quantidadeParcelas ?? 0,
+        ),
+      },
+      porMetodoPagamento,
+      porTipoPagamento,
+    };
+  }
+
+  /** Função principal que orquestra o retorno geral do dashboard */
+  async retornoTotalDashboard(
+    inicioParam?: string,
+    fimParam?: string,
+  ): Promise<DashboardReturnDto> {
+    const dataFim = fimParam ? new Date(fimParam) : new Date();
+    dataFim.setHours(23, 59, 59, 999);
+
+    const dataInicio = inicioParam
+      ? new Date(inicioParam)
+      : new Date(new Date(dataFim).setMonth(new Date(dataFim).getMonth() - 6));
+    dataInicio.setHours(0, 0, 0, 0);
+
+    // ─── Execução paralela de todas as queries ───────────────────────────────
+
+    const [geral, veiculos, servicos, financeiro] = await Promise.all([
+      this.obterDadosGerais(dataInicio, dataFim),
+      this.obterDadosVeiculos(),
+      this.obterDadosServicos(dataInicio, dataFim),
+      this.obterDadosFinanceiro(dataInicio, dataFim),
+    ]);
+
+    // ─── Solicitações depende de dados gerais ────────────────────────────────
+
+    const solicitacoes = await this.obterDadosSolicitacoes(
+      dataInicio,
+      dataFim,
+      geral.porStatus,
+      geral.statusAbertos,
+    );
+
+    // ─── Retorno consolidado ────────────────────────────────────────────────
 
     return {
       geral: {
-        solicitacoesEmAberto,
-        solicitacoesConcluidas,
-        documentosPendentesValidacao,
-        clientesNovosMesAtual,
-        taxaCancelamentoPct,
-        debitosEmAberto,
-        parcelasVencidasNaoPagas,
+        solicitacoesEmAberto: geral.solicitacoesEmAberto,
+        solicitacoesConcluidas: geral.solicitacoesConcluidas,
+        documentosPendentesValidacao: geral.documentosPendentesValidacao,
+        clientesNovosMesAtual: geral.clientesNovosMesAtual,
+        taxaCancelamentoPct: geral.taxaCancelamentoPct,
+        debitosEmAberto: geral.debitosEmAberto,
+        parcelasVencidasNaoPagas: geral.parcelasVencidasNaoPagas,
       },
-      solicitacoes: {
-        porStatus,
-        proximasDeVencer: {
-          quantidade: proximasDeVencerQuantidade,
-        },
-        tempoConclusaoPorServico,
-        foraDoPrazo: {
-          quantidade: foraDoPrazoQuantidade,
-          totalConcluidas,
-          percentual,
-        },
-      },
-      servicos: {
-        ativos: servicosAtivos,
-        pausados: servicosPausados,
-        maisSolicitados,
-        receitaPorServicoCompleto,
-      },
-      financeiro: {
-        receitaRealizada,
-        receitaPendente,
-        receitaTaxa,
-        ticketMedio,
-        mediaMensalReceita,
-        historicoMensal,
-        inadimplencia,
-        previsaoCaixa30Dias,
-        porMetodoPagamento,
-        porTipoPagamento,
-      },
-      veiculos: {
-        totalCadastrados: totalVeiculosCadastrados,
-        comSolicitacaoAtiva: veiculosComSolicitacaoAtiva,
-        comDebitoPendente: porVeiculo.length,
-        debitosPendentes: {
-          valorTotal: valorTotalGeral,
-          porVeiculo,
-        },
-      },
+      solicitacoes,
+      servicos,
+      financeiro,
+      veiculos,
     };
   }
 }

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -409,9 +409,10 @@ export class DashboardService {
 
   /** Retorna dados de serviços: ativos, pausados e receita por serviço */
   private async obterDadosServicos(
-    dataInicio: Date,
-    dataFim: Date,
+    inicio?: string,
+    fim?: string,
   ): Promise<ServicosDto> {
+    const { dataInicio, dataFim } = this.converterData(fim, inicio);
     const servicosAtivos = await this.servicoModel.count({
       where: { ativo: true },
     });
@@ -667,7 +668,7 @@ export class DashboardService {
     const [geral, veiculos, servicos, financeiro] = await Promise.all([
       this.obterDadosGerais(inicioParam, fimParam),
       this.obterDadosVeiculos(),
-      this.obterDadosServicos(dataInicio, dataFim),
+      this.obterDadosServicos(inicioParam, fimParam),
       this.obterDadosFinanceiro(dataInicio, dataFim),
     ]);
 

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -343,7 +343,7 @@ export class DashboardService {
   }
 
   /** Retorna dados de veículos: cadastrados, com solicitações ativas e débitos pendentes */
-  private async obterDadosVeiculos(): Promise<VeiculosDto> {
+  async obterDadosVeiculos(): Promise<VeiculosDto> {
     const totalVeiculosCadastrados = await this.veiculoModel.count();
 
     const veiculosComSolicitacaoAtiva = await this.solicitacaoModel.count({

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -30,24 +30,31 @@ import type {
   ResultadoDistribuicaoMetodo,
   ResultadoDistribuicaoTipo,
 } from './dashboard.types';
-import {
-  MaisSolicitadosRow,
-  ReceitaPorServicoRow,
-  StatusCountRow,
-  TempoConclusaoRow,
-} from './dashboard.types';
+import { MaisSolicitadosRow, ReceitaPorServicoRow } from './dashboard.types';
 
-// Interface auxiliar para o retorno de obterDadosGerais
-interface DadosGeraisComStatus extends GeralDto {
-  porStatus: {
-    recebido: number;
-    emAndamento: number;
-    aguardandoPagamento: number;
-    aguardandoDocumento: number;
-    concluido: number;
-    cancelado: number;
-  };
-  statusAbertos: string[];
+interface StatusCountRaw {
+  status: string;
+  quantidade: number | string;
+}
+
+interface ParcelasVencidasRaw {
+  valorTotal: number | string | null;
+  quantidadeParcelas: number | string | null;
+}
+
+interface TempoConclusaoRaw {
+  servicoId: number | string;
+  servicoNome: string;
+  prazoEstimadoDias: number | string;
+  mediaRealDias: number | string;
+  totalConcluidas: number | string;
+}
+
+interface DebitoVeiculoRaw {
+  idVeiculo: number;
+  totalDebitos: number | string;
+  valorTotal: number | string;
+  veiculo: { placa: string };
 }
 
 @Injectable()
@@ -92,11 +99,23 @@ export class DashboardService {
     return meses;
   }
 
+  private converterData(fimParam?: string, inicioParam?: string) {
+    const dataFim = fimParam ? new Date(fimParam) : new Date();
+    dataFim.setHours(23, 59, 59, 999);
+
+    const dataInicio = inicioParam
+      ? new Date(inicioParam)
+      : new Date(new Date(dataFim).setMonth(new Date(dataFim).getMonth() - 6));
+    dataInicio.setHours(0, 0, 0, 0);
+    return { dataInicio, dataFim };
+  }
+
   /** Retorna dados gerais: solicitações, documentos, clientes e débitos do período */
-  private async obterDadosGerais(
-    dataInicio: Date,
-    dataFim: Date,
+  async obterDadosGerais(
+    inicio?: string,
+    fim?: string,
   ): Promise<DadosGeraisComStatus> {
+    const { dataInicio, dataFim } = this.converterData(fim, inicio);
     const hoje = new Date();
 
     const statusAbertos = [
@@ -116,7 +135,7 @@ export class DashboardService {
       },
       group: [col('Solicitacao.status')],
       raw: true,
-    })) as unknown as any[];
+    })) as unknown as StatusCountRaw[];
 
     const documentosPendentesValidacao =
       await this.documentoSolicitacaoModel.count({
@@ -155,7 +174,7 @@ export class DashboardService {
         status: { [Op.ne]: 'pago' },
       },
       raw: true,
-    })) as any;
+    })) as ParcelasVencidasRaw | null;
 
     const porStatusBase = {
       recebido: 0,
@@ -185,9 +204,10 @@ export class DashboardService {
       porStatus.aguardandoPagamento +
       porStatus.aguardandoDocumento;
 
-    const totalSolicitacoesPeriodo: number = (
-      Object.values(porStatus) as number[]
-    ).reduce((a: number, b: number) => a + b, 0);
+    const totalSolicitacoesPeriodo: number = Object.values(porStatus).reduce(
+      (a: number, b: number) => a + b,
+      0,
+    );
 
     const taxaCancelamentoPct =
       totalSolicitacoesPeriodo > 0
@@ -210,18 +230,57 @@ export class DashboardService {
         quantidade: Number(parcelasVencidasResult?.quantidadeParcelas ?? 0),
         valorTotal: Number(parcelasVencidasResult?.valorTotal ?? 0),
       },
-      porStatus,
-      statusAbertos,
     };
   }
 
   /** Retorna dados de solicitações: status, prazos, tempo de conclusão */
-  private async obterDadosSolicitacoes(
-    dataInicio: Date,
-    dataFim: Date,
-    porStatus: any,
-    statusAbertos: string[],
+  async obterDadosSolicitacoes(
+    inicio?: string,
+    fim?: string,
   ): Promise<SolicitacoesDto> {
+    const { dataInicio, dataFim } = this.converterData(fim, inicio);
+
+    const statusAbertos = [
+      'recebido',
+      'aguardando_pagamento',
+      'aguardando_documento',
+      'em_andamento',
+    ];
+
+    const porStatusRaw = (await this.solicitacaoModel.findAll({
+      attributes: [
+        'status',
+        [fn('COUNT', col('Solicitacao.id')), 'quantidade'],
+      ],
+      where: {
+        dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+      },
+      group: [col('Solicitacao.status')],
+      raw: true,
+    })) as unknown as StatusCountRaw[];
+
+    const porStatusBase = {
+      recebido: 0,
+      emAndamento: 0,
+      aguardandoPagamento: 0,
+      aguardandoDocumento: 0,
+      concluido: 0,
+      cancelado: 0,
+    };
+
+    const porStatus = porStatusRaw.reduce((acc, item) => {
+      const quantidade = Number(item.quantidade ?? 0);
+      if (item.status === 'recebido') acc.recebido = quantidade;
+      if (item.status === 'em_andamento') acc.emAndamento = quantidade;
+      if (item.status === 'aguardando_pagamento')
+        acc.aguardandoPagamento = quantidade;
+      if (item.status === 'aguardando_documento')
+        acc.aguardandoDocumento = quantidade;
+      if (item.status === 'concluido') acc.concluido = quantidade;
+      if (item.status === 'cancelado') acc.cancelado = quantidade;
+      return acc;
+    }, porStatusBase);
+
     const proximasDeVencer = await this.solicitacaoModel.count({
       include: [{ model: Servico, attributes: [], required: true }],
       where: {
@@ -268,7 +327,7 @@ export class DashboardService {
       ],
       order: [[literal('mediaRealDias'), 'DESC']],
       raw: true,
-    })) as unknown as any[];
+    })) as unknown as TempoConclusaoRaw[];
 
     const foraDoPrazoQuantidade = await this.solicitacaoModel.count({
       include: [{ model: Servico, attributes: [], required: true }],
@@ -354,23 +413,14 @@ export class DashboardService {
       group: ['idVeiculo', 'veiculo.id'],
       raw: true,
       nest: true,
-    })) as unknown as any[];
+    })) as unknown as DebitoVeiculoRaw[];
 
-    interface DebitoVeiculoRaw {
-      idVeiculo: number;
-      totalDebitos: string;
-      valorTotal: string;
-      veiculo: { placa: string };
-    }
-
-    const porVeiculo = (debitosPendentesResult as DebitoVeiculoRaw[]).map(
-      (item) => ({
-        veiculoId: item.idVeiculo,
-        placa: item.veiculo.placa,
-        totalDebitos: Number(item.totalDebitos),
-        valorTotal: Number(item.valorTotal),
-      }),
-    );
+    const porVeiculo = debitosPendentesResult.map((item) => ({
+      veiculoId: item.idVeiculo,
+      placa: item.veiculo.placa,
+      totalDebitos: Number(item.totalDebitos),
+      valorTotal: Number(item.valorTotal),
+    }));
 
     const valorTotalGeral = porVeiculo.reduce(
       (acc, item) => acc + item.valorTotal,
@@ -413,7 +463,7 @@ export class DashboardService {
       group: ['servico.id', 'Solicitacao.servico_id'],
       order: [[literal('totalSolicitacoes'), 'DESC']],
       limit: 5,
-    })) as unknown as any[];
+    })) as unknown as MaisSolicitadosRow[];
 
     const receitaPorServicoRaw = (await this.debitoServicoModel.findAll({
       attributes: [
@@ -433,24 +483,20 @@ export class DashboardService {
       group: ['servico.id', 'DebitoServico.id_servico'],
       order: [[literal('receitaTotal'), 'DESC']],
       limit: 5,
-    })) as unknown as any[];
+    })) as unknown as ReceitaPorServicoRow[];
 
     const todosServicos = await this.servicoModel.findAll({
       where: { ativo: true },
       attributes: ['id', 'nome'],
     });
 
-    const maisSolicitados = (maisSolicitadosRaw as MaisSolicitadosRow[]).map(
-      (item) => ({
-        servicoId: Number(item.get('servicoId') ?? 0),
-        nome: item.servico?.nome ?? '',
-        totalSolicitacoes: Number(item.get('totalSolicitacoes') ?? 0),
-      }),
-    );
+    const maisSolicitados = maisSolicitadosRaw.map((item) => ({
+      servicoId: Number(item.get('servicoId') ?? 0),
+      nome: item.servico?.nome ?? '',
+      totalSolicitacoes: Number(item.get('totalSolicitacoes') ?? 0),
+    }));
 
-    const receitaPorServico = (
-      receitaPorServicoRaw as ReceitaPorServicoRow[]
-    ).map((item) => ({
+    const receitaPorServico = receitaPorServicoRaw.map((item) => ({
       servicoId: Number(item.get('servicoId') ?? 0),
       nome: item.servico?.nome ?? '',
       totalSolicitacoes: Number(item.get('totalSolicitacoes') ?? 0),
@@ -490,7 +536,7 @@ export class DashboardService {
       include: [{ model: Debito, where: { status: 'pago' }, attributes: [] }],
       where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
       raw: true,
-    })) as any;
+    })) as ResultadoReceita | null;
 
     const receitaPendente = await this.debitoModel.sum('valor', {
       where: { status: 'pendente' },
@@ -504,7 +550,7 @@ export class DashboardService {
       attributes: [[fn('AVG', col('valor_total')), 'media']],
       where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
       raw: true,
-    })) as any;
+    })) as ResultadoTicketMedio | null;
 
     const historicoMensalResult = (await this.pagamentoModel.findAll({
       attributes: [
@@ -515,7 +561,7 @@ export class DashboardService {
       group: [fn('DATE_FORMAT', col('created_at'), '%Y-%m')],
       order: [[fn('DATE_FORMAT', col('created_at'), '%Y-%m'), 'ASC']],
       raw: true,
-    })) as any[];
+    })) as unknown as ResultadoHistoricoMensal[];
 
     const inadimplenciaResult = (await this.parcelaModel.findOne({
       attributes: [
@@ -528,7 +574,7 @@ export class DashboardService {
         status: { [Op.ne]: 'pago' },
       },
       raw: true,
-    })) as any;
+    })) as ResultadoInadimplencia | null;
 
     const previsaoCaixaResult = (await this.parcelaModel.findOne({
       attributes: [
@@ -540,7 +586,7 @@ export class DashboardService {
         status: { [Op.ne]: 'pago' },
       },
       raw: true,
-    })) as any;
+    })) as ResultadoPrevisaoCaixa | null;
 
     const porMetodoResult = (await this.pagamentoModel.findAll({
       attributes: [
@@ -551,7 +597,7 @@ export class DashboardService {
       where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
       group: ['metodo_pagamento'],
       raw: true,
-    })) as any[];
+    })) as unknown as ResultadoDistribuicaoMetodo[];
 
     const porTipoResult = (await this.pagamentoModel.findAll({
       attributes: [
@@ -562,7 +608,7 @@ export class DashboardService {
       where: { createdAt: { [Op.between]: [dataInicio, dataFim] } },
       group: ['tipo_pagamento'],
       raw: true,
-    })) as any[];
+    })) as unknown as ResultadoDistribuicaoTipo[];
 
     // ─── Processamento dos dados financeiros ─────────────────────────────────
 
@@ -650,17 +696,15 @@ export class DashboardService {
     dataInicio.setHours(0, 0, 0, 0);
 
     const [geral, veiculos, servicos, financeiro] = await Promise.all([
-      this.obterDadosGerais(dataInicio, dataFim),
+      this.obterDadosGerais(inicioParam, fimParam),
       this.obterDadosVeiculos(),
       this.obterDadosServicos(dataInicio, dataFim),
       this.obterDadosFinanceiro(dataInicio, dataFim),
     ]);
 
     const solicitacoes = await this.obterDadosSolicitacoes(
-      dataInicio,
-      dataFim,
-      geral.porStatus,
-      geral.statusAbertos,
+      inicioParam,
+      fimParam,
     );
 
     return {

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -649,8 +649,6 @@ export class DashboardService {
       : new Date(new Date(dataFim).setMonth(new Date(dataFim).getMonth() - 6));
     dataInicio.setHours(0, 0, 0, 0);
 
-    // ─── Execução paralela de todas as queries ───────────────────────────────
-
     const [geral, veiculos, servicos, financeiro] = await Promise.all([
       this.obterDadosGerais(dataInicio, dataFim),
       this.obterDadosVeiculos(),
@@ -658,16 +656,12 @@ export class DashboardService {
       this.obterDadosFinanceiro(dataInicio, dataFim),
     ]);
 
-    // ─── Solicitações depende de dados gerais ────────────────────────────────
-
     const solicitacoes = await this.obterDadosSolicitacoes(
       dataInicio,
       dataFim,
       geral.porStatus,
       geral.statusAbertos,
     );
-
-    // ─── Retorno consolidado ────────────────────────────────────────────────
 
     return {
       geral: {

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -658,13 +658,6 @@ export class DashboardService {
     inicioParam?: string,
     fimParam?: string,
   ): Promise<DashboardReturnDto> {
-    const dataFim = fimParam ? new Date(fimParam) : new Date();
-    dataFim.setHours(23, 59, 59, 999);
-
-    const dataInicio = inicioParam
-      ? new Date(inicioParam)
-      : new Date(new Date(dataFim).setMonth(new Date(dataFim).getMonth() - 6));
-    dataInicio.setHours(0, 0, 0, 0);
 
     const [geral, solicitacoes, veiculos, servicos, financeiro] =
       await Promise.all([

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -298,7 +298,10 @@ export class DashboardService {
         },
       }),
       this.solicitacaoModel.count({
-        where: { status: 'concluido' },
+        where: {
+          status: 'concluido',
+          dataConclusao: { [Op.between]: [dataInicio, dataFim] },
+        },
       }),
     ]);
 

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -78,7 +78,7 @@ export class DashboardService {
     return meses;
   }
 
-  private converterData(fimParam?: string, inicioParam?: string) {
+  private converterData(inicioParam?: string, fimParam?: string) {
     const dataFim = fimParam ? new Date(fimParam) : new Date();
     dataFim.setHours(23, 59, 59, 999);
 
@@ -91,7 +91,7 @@ export class DashboardService {
 
   /** Retorna dados gerais: solicitações, documentos, clientes e débitos do período */
   async obterDadosGerais(inicio?: string, fim?: string): Promise<GeralDto> {
-    const { dataInicio, dataFim } = this.converterData(fim, inicio);
+    const { dataInicio, dataFim } = this.converterData(inicio, fim);
     const hoje = new Date();
 
     const [
@@ -210,7 +210,7 @@ export class DashboardService {
     inicio?: string,
     fim?: string,
   ): Promise<SolicitacoesDto> {
-    const { dataInicio, dataFim } = this.converterData(fim, inicio);
+    const { dataInicio, dataFim } = this.converterData(inicio, fim);
 
     const statusAbertos = [
       'recebido',
@@ -423,7 +423,7 @@ export class DashboardService {
     inicio?: string,
     fim?: string,
   ): Promise<ServicosDto> {
-    const { dataInicio, dataFim } = this.converterData(fim, inicio);
+    const { dataInicio, dataFim } = this.converterData(inicio, fim);
     const [
       servicosAtivos,
       servicosPausados,
@@ -515,7 +515,7 @@ export class DashboardService {
     inicio?: string,
     fim?: string,
   ): Promise<FinanceiroDto> {
-    const { dataInicio, dataFim } = this.converterData(fim, inicio);
+    const { dataInicio, dataFim } = this.converterData(inicio, fim);
     const hoje = new Date();
     const em30Dias = new Date(hoje.getTime() + 30 * 24 * 60 * 60 * 1000);
 

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -666,17 +666,14 @@ export class DashboardService {
       : new Date(new Date(dataFim).setMonth(new Date(dataFim).getMonth() - 6));
     dataInicio.setHours(0, 0, 0, 0);
 
-    const [geral, veiculos, servicos, financeiro] = await Promise.all([
-      this.obterDadosGerais(inicioParam, fimParam),
-      this.obterDadosVeiculos(),
-      this.obterDadosServicos(inicioParam, fimParam),
-      this.obterDadosFinanceiro(inicioParam, fimParam),
-    ]);
-
-    const solicitacoes = await this.obterDadosSolicitacoes(
-      inicioParam,
-      fimParam,
-    );
+    const [geral, solicitacoes, veiculos, servicos, financeiro] =
+      await Promise.all([
+        this.obterDadosGerais(inicioParam, fimParam),
+        this.obterDadosSolicitacoes(inicioParam, fimParam),
+        this.obterDadosVeiculos(),
+        this.obterDadosServicos(inicioParam, fimParam),
+        this.obterDadosFinanceiro(inicioParam, fimParam),
+      ]);
 
     return {
       geral: {

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -29,33 +29,12 @@ import type {
   ResultadoPrevisaoCaixa,
   ResultadoDistribuicaoMetodo,
   ResultadoDistribuicaoTipo,
+  StatusCountRaw,
+  ParcelasVencidasRaw,
+  TempoConclusaoRaw,
+  DebitoVeiculoRaw,
 } from './dashboard.types';
 import { MaisSolicitadosRow, ReceitaPorServicoRow } from './dashboard.types';
-
-interface StatusCountRaw {
-  status: string;
-  quantidade: number | string;
-}
-
-interface ParcelasVencidasRaw {
-  valorTotal: number | string | null;
-  quantidadeParcelas: number | string | null;
-}
-
-interface TempoConclusaoRaw {
-  servicoId: number | string;
-  servicoNome: string;
-  prazoEstimadoDias: number | string;
-  mediaRealDias: number | string;
-  totalConcluidas: number | string;
-}
-
-interface DebitoVeiculoRaw {
-  idVeiculo: number;
-  totalDebitos: number | string;
-  valorTotal: number | string;
-  veiculo: { placa: string };
-}
 
 @Injectable()
 export class DashboardService {
@@ -111,19 +90,9 @@ export class DashboardService {
   }
 
   /** Retorna dados gerais: solicitações, documentos, clientes e débitos do período */
-  async obterDadosGerais(
-    inicio?: string,
-    fim?: string,
-  ): Promise<DadosGeraisComStatus> {
+  async obterDadosGerais(inicio?: string, fim?: string): Promise<GeralDto> {
     const { dataInicio, dataFim } = this.converterData(fim, inicio);
     const hoje = new Date();
-
-    const statusAbertos = [
-      'recebido',
-      'aguardando_pagamento',
-      'aguardando_documento',
-      'em_andamento',
-    ];
 
     const porStatusRaw = (await this.solicitacaoModel.findAll({
       attributes: [

--- a/src/modules/dashboard/dashboard.types.ts
+++ b/src/modules/dashboard/dashboard.types.ts
@@ -38,6 +38,31 @@ export interface ResultadoDistribuicaoTipo {
   valorTotal: string | null;
 }
 
+export interface StatusCountRaw {
+  status: string;
+  quantidade: number | string;
+}
+
+export interface ParcelasVencidasRaw {
+  valorTotal: number | string | null;
+  quantidadeParcelas: number | string | null;
+}
+
+export interface TempoConclusaoRaw {
+  servicoId: number | string;
+  servicoNome: string;
+  prazoEstimadoDias: number | string;
+  mediaRealDias: number | string;
+  totalConcluidas: number | string;
+}
+
+export interface DebitoVeiculoRaw {
+  idVeiculo: number;
+  totalDebitos: number | string;
+  valorTotal: number | string;
+  veiculo: { placa: string };
+}
+
 export type MaisSolicitadosRow = Solicitacao & {
   servico?: Servico;
   get(key: 'servicoId' | 'totalSolicitacoes'): string | number | null;

--- a/src/modules/dashboard/dashboard.types.ts
+++ b/src/modules/dashboard/dashboard.types.ts
@@ -74,16 +74,3 @@ export type ReceitaPorServicoRow = DebitoServico & {
     key: 'servicoId' | 'totalSolicitacoes' | 'receitaTotal',
   ): string | number | null;
 };
-
-export type StatusCountRow = {
-  status: string;
-  quantidade: number | string;
-};
-
-export type TempoConclusaoRow = {
-  servicoId: number | string;
-  servicoNome: string;
-  prazoEstimadoDias: number | string;
-  mediaRealDias: number | string;
-  totalConcluidas: number | string;
-};


### PR DESCRIPTION
### Esse PR refatora todo o dashboard service para migrar de uma grande função com varias queries para diferentes funções com queries individuais (para cada "parte" do retorno do dashboard), além disso, cria endpoints separados para cada sessão

# Exemplos:

## Antes:
```
 async retornarInfosDashboard(
    inicioParam?: string,
    fimParam?: string,
  ): Promise<DashboardReturnDto> { <todas as queries aqui> }
```

## Depois


```typescript
  private async obterDadosGerais(
    dataInicio: Date,
    dataFim: Date,
  ): Promise<DadosGeraisComStatus> {<apenas a query geral>}

```
```typescript

  private async obterDadosSolicitacoes(
    dataInicio: Date,
    dataFim: Date,
    porStatus: any,
    statusAbertos: string[],
  ): Promise<SolicitacoesDto> {<apenas a query de solicitacoes>}
```

```typescript
 # funcao que agrega todas as outras (no caso da necessidade de uma rota TOTAL)
  async retornoTotalDashboard(
    inicioParam?: string,
    fimParam?: string,
  ): Promise<DashboardReturnDto> {}
```
closes #239 




