### PR TITLE
Feat: recomendar serviço de transferência de propriedade

### DIFF
--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -395,10 +395,56 @@ describe('RecomendacaoService', () => {
     });
   });
 
+  describe('buscarTransferenciaPropriedade', () => {
+    it('deve retornar recomendação (ID 2) se veículo não tiver transferência ativa', async () => {
+      mockVeiculoModel.findAll.mockResolvedValue([
+        { id: 3 } as unknown as Veiculo,
+      ]);
+      mockSolicitacaoModel.findOne.mockResolvedValue(null);
+
+      const resultado = await service.buscarTransferenciaPropriedade(1);
+
+      expect(resultado).not.toBeNull();
+      expect(resultado?.id).toBe(2);
+      expect(resultado?.nome).toBe('Transferência de Propriedade');
+    });
+
+    it('deve retornar null se já existe solicitação ativa para o veículo', async () => {
+      mockVeiculoModel.findAll.mockResolvedValue([
+        { id: 3 } as unknown as Veiculo,
+      ]);
+      mockSolicitacaoModel.findOne.mockResolvedValue({
+        id: 20,
+        servicoId: 2,
+        status: 'pendente',
+      } as unknown as Solicitacao);
+
+      const resultado = await service.buscarTransferenciaPropriedade(1);
+      expect(resultado).toBeNull();
+    });
+
+    it('deve retornar null se o usuário não tiver veículos', async () => {
+      mockVeiculoModel.findAll.mockResolvedValue([]);
+
+      const resultado = await service.buscarTransferenciaPropriedade(1);
+      expect(resultado).toBeNull();
+    });
+
+    it('deve retornar null em caso de erro técnico', async () => {
+      mockVeiculoModel.findAll.mockRejectedValue(new Error('Erro de banco'));
+
+      const resultado = await service.buscarTransferenciaPropriedade(1);
+      expect(resultado).toBeNull();
+    });
+  });
+
   describe('obterRecomendacoes', () => {
     it('deve retornar uma lista com múltiplos serviços se o usuário tiver multa e venda', async () => {
       jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRenovacaoCNH').mockResolvedValue(null);
+      jest
+        .spyOn(service, 'buscarTransferenciaPropriedade')
+        .mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue({
         id: 6,
         nome: 'Multa',
@@ -426,6 +472,9 @@ describe('RecomendacaoService', () => {
     it('deve retornar serviços populares se a lista de prioridades estiver vazia', async () => {
       jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRenovacaoCNH').mockResolvedValue(null);
+      jest
+        .spyOn(service, 'buscarTransferenciaPropriedade')
+        .mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue(null);
       jest.spyOn(service, 'buscarParcelamentoDebitos').mockResolvedValue(null);
       jest.spyOn(service, 'buscarComunicacaoVenda').mockResolvedValue(null);

--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -264,16 +264,20 @@ describe('RecomendacaoService', () => {
       expect(resultado?.nome).toBe('Licenciamento Anual');
     });
 
-    it('deve retornar null se o veículo ainda não atingiu o mês de gatilho', async () => {
-      // Dígito '0' tem gatilho em novembro (11), só dispara se mesAtual >= 11
-      // Forçamos um cenário onde o mês atual é anterior ao gatilho
+    it('deve seguir para buscarRenovacaoCNH se o veículo não atingiu o mês de gatilho', async () => {
       mockVeiculoModel.findAll.mockResolvedValue([
-        { id: 5, placa: 'ABC1230', ativo: true } as unknown as Veiculo,
+        { id: 5, placa: 'ABC1230' } as unknown as Veiculo,
       ]);
 
       jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0); // Janeiro
 
+      const spyCNH = jest
+        .spyOn(service, 'buscarRenovacaoCNH')
+        .mockResolvedValue(null);
+
       const resultado = await service.buscarLicenciamentoAnual(1);
+
+      expect(spyCNH).toHaveBeenCalledWith(1);
       expect(resultado).toBeNull();
 
       jest.restoreAllMocks();
@@ -311,6 +315,40 @@ describe('RecomendacaoService', () => {
       } as unknown as Solicitacao);
 
       const resultado = await service.buscarLicenciamentoAnual(1);
+      expect(resultado).toBeNull();
+    });
+  });
+
+  describe('buscarRenovacaoCNH', () => {
+    it('deve retornar recomendação (ID 4) se não houver solicitação nos últimos 10 anos', async () => {
+      mockSolicitacaoModel.findOne.mockResolvedValue(null);
+
+      const resultado = await service.buscarRenovacaoCNH(1);
+
+      expect(resultado).not.toBeNull();
+      expect(resultado?.id).toBe(4);
+      expect(resultado?.nome).toBe('Renovação de CNH');
+    });
+
+    it('deve retornar null se já existe solicitação ativa nos últimos 10 anos', async () => {
+      mockSolicitacaoModel.findOne.mockResolvedValue({
+        id: 50,
+        servicoId: 4,
+        status: 'concluido',
+      } as unknown as Solicitacao);
+
+      const resultado = await service.buscarRenovacaoCNH(1);
+
+      expect(resultado).toBeNull();
+    });
+
+    it('deve retornar null em caso de erro técnico para não travar o fluxo', async () => {
+      mockSolicitacaoModel.findOne.mockRejectedValue(
+        new Error('Erro de banco'),
+      );
+
+      const resultado = await service.buscarRenovacaoCNH(1);
+
       expect(resultado).toBeNull();
     });
   });
@@ -365,6 +403,7 @@ describe('RecomendacaoService', () => {
   describe('obterRecomendacoes', () => {
     it('deve retornar uma lista com múltiplos serviços se o usuário tiver multa e venda', async () => {
       jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
+      jest.spyOn(service, 'buscarRenovacaoCNH').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue({
         id: 6,
         nome: 'Multa',
@@ -391,6 +430,7 @@ describe('RecomendacaoService', () => {
 
     it('deve retornar serviços populares se a lista de prioridades estiver vazia', async () => {
       jest.spyOn(service, 'buscarLicenciamentoAnual').mockResolvedValue(null);
+      jest.spyOn(service, 'buscarRenovacaoCNH').mockResolvedValue(null);
       jest.spyOn(service, 'buscarRecursoMulta').mockResolvedValue(null);
       jest.spyOn(service, 'buscarParcelamentoDebitos').mockResolvedValue(null);
       jest.spyOn(service, 'buscarComunicacaoVenda').mockResolvedValue(null);

--- a/src/modules/recomendacao/recomendacao.service.spec.ts
+++ b/src/modules/recomendacao/recomendacao.service.spec.ts
@@ -264,20 +264,15 @@ describe('RecomendacaoService', () => {
       expect(resultado?.nome).toBe('Licenciamento Anual');
     });
 
-    it('deve seguir para buscarRenovacaoCNH se o veículo não atingiu o mês de gatilho', async () => {
+    it('deve retornar null se o veículo não atingiu o mês de gatilho', async () => {
       mockVeiculoModel.findAll.mockResolvedValue([
         { id: 5, placa: 'ABC1230' } as unknown as Veiculo,
       ]);
 
       jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(0); // Janeiro
 
-      const spyCNH = jest
-        .spyOn(service, 'buscarRenovacaoCNH')
-        .mockResolvedValue(null);
-
       const resultado = await service.buscarLicenciamentoAnual(1);
 
-      expect(spyCNH).toHaveBeenCalledWith(1);
       expect(resultado).toBeNull();
 
       jest.restoreAllMocks();

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -44,6 +44,10 @@ export class RecomendacaoService {
       const cnh = await this.buscarRenovacaoCNH(usuarioId);
       if (cnh) listaRecomendacoes.push(cnh);
 
+      const transferencia =
+        await this.buscarTransferenciaPropriedade(usuarioId);
+      if (transferencia) listaRecomendacoes.push(transferencia);
+
       const infracao = await this.buscarRecursoMulta(usuarioId);
       if (infracao) {
         listaRecomendacoes.push(infracao);
@@ -90,6 +94,47 @@ export class RecomendacaoService {
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(`Erro ao gerar recomendações: ${errorMessage}`);
       throw new InternalServerErrorException('Erro ao processar recomendações');
+    }
+  }
+
+  async buscarTransferenciaPropriedade(
+    usuarioId: number,
+  ): Promise<RecomendacaoRespostaDto | null> {
+    try {
+      const veiculos = await this.veiculoModel.findAll({
+        where: { usuarioId },
+      });
+
+      for (const veiculo of veiculos) {
+        const jaExiste = await this.solicitacaoModel.findOne({
+          where: {
+            veiculoId: veiculo.id,
+            servicoId: 2,
+            status: {
+              [Op.ne]: 'cancelado',
+            },
+          },
+        });
+
+        if (!jaExiste) {
+          return {
+            id: 2,
+            nome: 'Transferência de Propriedade',
+            descricao:
+              'Identificamos que seu veículo ainda não possui transferência de titularidade. Regularize agora.',
+            ativo: true,
+          };
+        }
+      }
+
+      return null;
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erro desconhecido';
+      this.logger.error(
+        `Erro na busca de transferência de propriedade: ${errorMessage}`,
+      );
+      return null;
     }
   }
 

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -41,6 +41,9 @@ export class RecomendacaoService {
       const licenciamento = await this.buscarLicenciamentoAnual(usuarioId);
       if (licenciamento) listaRecomendacoes.push(licenciamento);
 
+      const cnh = await this.buscarRenovacaoCNH(usuarioId);
+      if (cnh) listaRecomendacoes.push(cnh);
+
       const infracao = await this.buscarRecursoMulta(usuarioId);
       if (infracao) {
         listaRecomendacoes.push(infracao);
@@ -129,7 +132,7 @@ export class RecomendacaoService {
               servicoId: 6,
               veiculoId: veiculo.id,
               status: {
-                [Op.notIn]: ['concluido', 'cancelado'],
+                [Op.notIn]: ['cancelado', 'rejeitado'],
               },
             },
           });
@@ -295,7 +298,7 @@ export class RecomendacaoService {
             veiculoId: veiculo.id,
             servicoId: 1,
             status: {
-              [Op.notIn]: ['cancelado', 'concluido'],
+              [Op.notIn]: ['cancelado', 'rejeitado'],
             },
             dataSolicitacao: {
               [Op.between]: [
@@ -316,14 +319,14 @@ export class RecomendacaoService {
         }
       }
 
-      return await this.buscarRenovacaoCNH(usuarioId);
+      return null;
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(
         `Erro na busca de licenciamento anual: ${errorMessage}`,
       );
-      return await this.buscarRenovacaoCNH(usuarioId);
+      return null;
     }
   }
 
@@ -339,7 +342,7 @@ export class RecomendacaoService {
           usuarioId,
           servicoId: 4,
           status: {
-            [Op.notIn]: ['cancelado', 'concluido'],
+            [Op.notIn]: ['cancelado', 'rejeitado'],
           },
           dataSolicitacao: {
             [Op.gte]: dezAnosAtras,
@@ -356,20 +359,13 @@ export class RecomendacaoService {
         };
       }
 
-      return await this.buscarTransferenciaPropriedade(usuarioId);
+      return null;
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(`Erro na busca de renovação de CNH: ${errorMessage}`);
       return null;
     }
-  }
-
-  protected async buscarTransferenciaPropriedade(usuarioId: number) {
-    this.logger.log(
-      `Seguindo para Transferência de Propriedade para usuário ${usuarioId}`,
-    );
-    return Promise.resolve(null);
   }
 
   private async buscarServicosPopulares() {

--- a/src/modules/recomendacao/recomendacao.service.ts
+++ b/src/modules/recomendacao/recomendacao.service.ts
@@ -38,7 +38,7 @@ export class RecomendacaoService {
     try {
       const listaRecomendacoes: RecomendacaoRespostaDto[] = [];
 
-      const licenciamento = await this.buscarLicenciamentoAnual(usuarioId); // << ADICIONAR
+      const licenciamento = await this.buscarLicenciamentoAnual(usuarioId);
       if (licenciamento) listaRecomendacoes.push(licenciamento);
 
       const infracao = await this.buscarRecursoMulta(usuarioId);
@@ -316,15 +316,60 @@ export class RecomendacaoService {
         }
       }
 
-      return null;
+      return await this.buscarRenovacaoCNH(usuarioId);
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : 'Erro desconhecido';
       this.logger.error(
         `Erro na busca de licenciamento anual: ${errorMessage}`,
       );
+      return await this.buscarRenovacaoCNH(usuarioId);
+    }
+  }
+
+  async buscarRenovacaoCNH(
+    usuarioId: number,
+  ): Promise<RecomendacaoRespostaDto | null> {
+    try {
+      const dezAnosAtras = new Date();
+      dezAnosAtras.setFullYear(dezAnosAtras.getFullYear() - 10);
+
+      const jaExiste = await this.solicitacaoModel.findOne({
+        where: {
+          usuarioId,
+          servicoId: 4,
+          status: {
+            [Op.notIn]: ['cancelado', 'concluido'],
+          },
+          dataSolicitacao: {
+            [Op.gte]: dezAnosAtras,
+          },
+        },
+      });
+
+      if (!jaExiste) {
+        return {
+          id: 4,
+          nome: 'Renovação de CNH',
+          descricao: 'Renove sua CNH',
+          ativo: true,
+        };
+      }
+
+      return await this.buscarTransferenciaPropriedade(usuarioId);
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erro desconhecido';
+      this.logger.error(`Erro na busca de renovação de CNH: ${errorMessage}`);
       return null;
     }
+  }
+
+  protected async buscarTransferenciaPropriedade(usuarioId: number) {
+    this.logger.log(
+      `Seguindo para Transferência de Propriedade para usuário ${usuarioId}`,
+    );
+    return Promise.resolve(null);
   }
 
   private async buscarServicosPopulares() {


### PR DESCRIPTION


## Descrição

Esta branch implementa a lógica proativa para recomendar o serviço de Transferência de Propriedade (ID 2). O método `buscarTransferenciaPropriedade` foi adicionado em `recomendacao.service.ts` e é chamado diretamente em `obterRecomendacoes`, após `buscarRenovacaoCNH`, seguindo o diagrama de prioridades do algoritmo de recomendações.

---

## Lógica implementada

O método recupera todos os veículos vinculados ao usuário e, para cada um, verifica na tabela `Solicitacao` se já existe registro onde:
- `servico_id = 2`
- `veiculo_id` corresponde ao veículo analisado
- `status` diferente de `cancelado`

Se não existir solicitação ativa, retorna a recomendação. Caso todos os veículos já possuam transferência, retorna `null` e o algoritmo segue para o próximo nível de prioridade.

---

## Como testar

**Pré-requisitos:**
- Subir o banco com `docker compose -f compose.dev.yml up --build -d` no repositório `database`
- Subir o servidor com `npm run start:dev` no repositório `back-end`
- Acessar o Swagger em `http://localhost:3000/swagger`

**Passo a passo:**

1. Acesse `GET /recomendacoes/{usuarioId}`

2. **Cenário positivo** — use `usuarioId: 2`
   - Não possui solicitação de Transferência de Propriedade cadastrada
   - Retorno esperado inclui `id: 2, nome: "Transferência de Propriedade"`

3. **Cenário negativo** — use `usuarioId: 3`
   - Já possui solicitação de Transferência com status `recebido`
   - Retorno **não deve** incluir `id: 2`
   - O algoritmo segue para o próximo nível de prioridade

---
Closes #157