### PR TITLE
feat: Implementação do endpoint GET usuario/:id

### DIFF
--- a/src/modules/usuario/usuario.controller.spec.ts
+++ b/src/modules/usuario/usuario.controller.spec.ts
@@ -14,6 +14,7 @@ const mockUsuarioService = {
   login: jest.fn(),
   remove: jest.fn(),
   update: jest.fn(),
+  findOne: jest.fn(),
   findAll: jest.fn(),
 };
 
@@ -225,6 +226,52 @@ describe('UsuarioController', () => {
       );
     });
   });
+  describe('findOne', () => {
+    it('deve retornar um usuário por id', async () => {
+      const usuario = {
+        id: 1,
+        nome: 'Arthur',
+        email: 'arthur@email.com',
+        nivel: 'cliente',
+        cpf_cnpj: null,
+        celular: null,
+        data_cadastro: new Date(),
+      };
+
+      mockUsuarioService.findOne.mockResolvedValue(usuario);
+
+      const result = await controller.findOne(1);
+
+      expect(mockUsuarioService.findOne).toHaveBeenCalledWith(1);
+      expect(result).toEqual(usuario);
+    });
+
+    it('deve propagar NotFoundException quando usuário não existir', async () => {
+      mockUsuarioService.findOne.mockRejectedValue(
+        new NotFoundException('Usuário não encontrado'),
+      );
+
+      await expect(controller.findOne(999)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('não deve retornar o campo senha', async () => {
+      const usuario = {
+        id: 1,
+        nome: 'Arthur',
+        email: 'arthur@email.com',
+        nivel: 'cliente',
+      };
+
+      mockUsuarioService.findOne.mockResolvedValue(usuario);
+
+      const result = await controller.findOne(1);
+
+      expect(result).not.toHaveProperty('senha');
+    });
+  });
+
 
   describe('findAll', () => {
     it('deve retornar uma lista de usuários', async () => {

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -71,4 +71,10 @@ export class UsuarioController {
   findAll() {
     return this.usuarioService.findAll();
   }
+
+  @Get(':id')
+  @UseGuards(UsuarioOwnerGuard)
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.usuarioService.findOne(id);
+  }
 }

--- a/src/modules/usuario/usuario.service.spec.ts
+++ b/src/modules/usuario/usuario.service.spec.ts
@@ -298,7 +298,39 @@ describe('UsuarioService', () => {
       ).resolves.not.toThrow();
     });
   });
+  
+describe('findOne', () => {
+  it('deve retornar um usuário por id sem senha', async () => {
+    mockUsuarioModel.findByPk.mockResolvedValue(mockUsuario);
 
+    const result = await service.findOne(1);
+
+    expect(mockUsuarioModel.findByPk).toHaveBeenCalledWith(1, {
+      attributes: { exclude: ['senha'] },
+    });
+
+    expect(result).toMatchObject({
+      id: mockUsuario.id,
+      nome: mockUsuario.nome,
+      email: mockUsuario.email,
+      nivel: mockUsuario.nivel,
+      cpf_cnpj: mockUsuario.cpfCnpj ?? null,
+      celular: mockUsuario.celular,
+      data_cadastro: mockUsuario.dataCadastro,
+    });
+
+    expect(result).not.toHaveProperty('senha');
+  });
+
+  it('deve lançar NotFoundException se usuário não existir', async () => {
+    mockUsuarioModel.findByPk.mockResolvedValue(null);
+
+    await expect(service.findOne(999)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});
+  
   describe('findAll', () => {
     it('deve retornar lista de usuários sem senha', async () => {
       const usuariosMock = [

--- a/src/modules/usuario/usuario.service.ts
+++ b/src/modules/usuario/usuario.service.ts
@@ -152,4 +152,18 @@ export class UsuarioService {
       excludeExtraneousValues: true,
     });
   }
+
+  async findOne(id: number): Promise<ResponseUsuarioDto> {
+    const usuario = await this.usuarioModel.findByPk(id, {
+      attributes: { exclude: ['senha'] },
+    });
+
+    if (!usuario) {
+      throw new NotFoundException('Usuário não encontrado');
+    }
+
+    return plainToInstance(ResponseUsuarioDto, usuario.get({ plain: true }), {
+      excludeExtraneousValues: true,
+    });
+  }
 }


### PR DESCRIPTION
Implementa o endpoint GET /usuario/:id para consulta de um usuário específico por ID.

Foi adicionado o método findOne no UsuarioService, responsável por buscar o usuário no banco, validar existência e retornar os dados utilizando ResponseUsuarioDto, sem expor a senha.

No UsuarioController, foi criada a rota GET /usuario/:id, protegida com UsuarioOwnerGuard, permitindo que:

usuários do tipo cliente visualizem apenas os próprios dados
usuários administradores visualizem qualquer usuário

Também foram adicionados testes unitários no usuario.controller.spec.ts e usuario.service.spec.ts cobrindo os cenários de sucesso e usuário não encontrado.

Closes #104