### PR TITLE
feature: implementar as queries restantes dashboard

### DIFF
--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -2,9 +2,9 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { ApiQuery, ApiTags } from '@nestjs/swagger';
 import { DashboardService } from './dashboard.service';
 import {
-  ClientesDashboardDto,
+  ClientesDto,
   DashboardReturnDto,
-  DocumentosDashboardDto,
+  DocumentosDto,
   FinanceiroDto,
   GeralDto,
   ServicosDto,
@@ -76,7 +76,7 @@ export class DashboardController {
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarDocumentosDashboard(
     @Query() query: DashboardPeriodoQueryDto,
-  ): Promise<DocumentosDashboardDto> {
+  ): Promise<DocumentosDto> {
     return this.dashboardService.obterDadosDocumentos(query.inicio, query.fim);
   }
 
@@ -85,7 +85,7 @@ export class DashboardController {
   @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
   async retornarClientesDashboard(
     @Query() query: DashboardPeriodoQueryDto,
-  ): Promise<ClientesDashboardDto> {
+  ): Promise<ClientesDto> {
     return this.dashboardService.obterDadosClientes(query.inicio, query.fim);
   }
 }

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -4,6 +4,7 @@ import { DashboardService } from './dashboard.service';
 import {
   ClientesDashboardDto,
   DashboardReturnDto,
+  DocumentosDashboardDto,
   FinanceiroDto,
   GeralDto,
   ServicosDto,
@@ -68,6 +69,15 @@ export class DashboardController {
     @Query() query: DashboardPeriodoQueryDto,
   ): Promise<FinanceiroDto> {
     return this.dashboardService.obterDadosFinanceiro(query.inicio, query.fim);
+  }
+
+  @Get('documentos')
+  @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
+  @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
+  async retornarDocumentosDashboard(
+    @Query() query: DashboardPeriodoQueryDto,
+  ): Promise<DocumentosDashboardDto> {
+    return this.dashboardService.obterDadosDocumentos(query.inicio, query.fim);
   }
 
   @Get('clientes')

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Query } from '@nestjs/common';
 import { ApiQuery, ApiTags } from '@nestjs/swagger';
 import { DashboardService } from './dashboard.service';
 import {
+  ClientesDashboardDto,
   DashboardReturnDto,
   FinanceiroDto,
   GeralDto,
@@ -67,5 +68,14 @@ export class DashboardController {
     @Query() query: DashboardPeriodoQueryDto,
   ): Promise<FinanceiroDto> {
     return this.dashboardService.obterDadosFinanceiro(query.inicio, query.fim);
+  }
+
+  @Get('clientes')
+  @ApiQuery({ name: 'inicio', required: false, example: '2025-01-01' })
+  @ApiQuery({ name: 'fim', required: false, example: '2025-06-30' })
+  async retornarClientesDashboard(
+    @Query() query: DashboardPeriodoQueryDto,
+  ): Promise<ClientesDashboardDto> {
+    return this.dashboardService.obterDadosClientes(query.inicio, query.fim);
   }
 }

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -19,8 +19,8 @@ import {
   VeiculosDto,
   ServicosDto,
   FinanceiroDto,
-  ClientesDashboardDto,
-  DocumentosDashboardDto,
+  ClientesDto,
+  DocumentosDto,
 } from './dto/dashboard-return.dto';
 import type { ModelCtor } from 'sequelize-typescript';
 import type {
@@ -687,7 +687,7 @@ export class DashboardService {
   async obterDadosClientes(
     inicio?: string,
     fim?: string,
-  ): Promise<ClientesDashboardDto> {
+  ): Promise<ClientesDto> {
     const { dataInicio, dataFim } = this.converterData(inicio, fim);
     const hoje = new Date();
     const [topPorVolumeRaw, topPorValorPagoRaw, comParcelasEmAtrasoRaw] =
@@ -800,33 +800,31 @@ export class DashboardService {
       ]);
 
     return {
-      clientes: {
-        topPorVolume: topPorVolumeRaw.map((item) => ({
-          usuarioId: Number(item.usuarioId),
-          nome: item.nome,
-          totalSolicitacoes: Number(item.totalSolicitacoes ?? 0),
-        })),
-        topPorValorPago: topPorValorPagoRaw.map((item) => ({
-          usuarioId: Number(item.usuarioId),
-          nome: item.nome,
-          valorTotalPago: Number(item.valorTotalPago ?? 0),
-        })),
-        comParcelasEmAtraso: comParcelasEmAtrasoRaw.map((item) => ({
-          usuarioId: Number(item.usuarioId),
-          nome: item.nome,
-          quantidadeParcelasAtrasadas: Number(
-            item.quantidadeParcelasAtrasadas ?? 0,
-          ),
-          valorTotalAtrasado: Number(item.valorTotalAtrasado ?? 0),
-        })),
-      },
+      topPorVolume: topPorVolumeRaw.map((item) => ({
+        usuarioId: Number(item.usuarioId),
+        nome: item.nome,
+        totalSolicitacoes: Number(item.totalSolicitacoes ?? 0),
+      })),
+      topPorValorPago: topPorValorPagoRaw.map((item) => ({
+        usuarioId: Number(item.usuarioId),
+        nome: item.nome,
+        valorTotalPago: Number(item.valorTotalPago ?? 0),
+      })),
+      comParcelasEmAtraso: comParcelasEmAtrasoRaw.map((item) => ({
+        usuarioId: Number(item.usuarioId),
+        nome: item.nome,
+        quantidadeParcelasAtrasadas: Number(
+          item.quantidadeParcelasAtrasadas ?? 0,
+        ),
+        valorTotalAtrasado: Number(item.valorTotalAtrasado ?? 0),
+      })),
     };
   }
 
   async obterDadosDocumentos(
     inicio?: string,
     fim?: string,
-  ): Promise<DocumentosDashboardDto> {
+  ): Promise<DocumentosDto> {
     const { dataInicio, dataFim } = this.converterData(inicio, fim);
 
     const [
@@ -882,16 +880,14 @@ export class DashboardService {
     );
 
     return {
-      documentos: {
-        pendentes: Number(pendentes ?? 0),
-        aprovados: Number(aprovados?.quantidade ?? 0),
-        rejeitados: Number(rejeitados?.quantidade ?? 0),
-        solicitacoesTravadas: Number(solicitacoesTravadas ?? 0),
-        rejeicoesPorTipo: rejeicoesPorTipoRaw.map((item) => ({
-          tipoDocumento: item.tipoDocumento ?? 'nao_informado',
-          totalRejeitados: Number(item.totalRejeitados ?? 0),
-        })),
-      },
+      pendentes: Number(pendentes ?? 0),
+      aprovados: Number(aprovados?.quantidade ?? 0),
+      rejeitados: Number(rejeitados?.quantidade ?? 0),
+      solicitacoesTravadas: Number(solicitacoesTravadas ?? 0),
+      rejeicoesPorTipo: rejeicoesPorTipoRaw.map((item) => ({
+        tipoDocumento: item.tipoDocumento ?? 'nao_informado',
+        totalRejeitados: Number(item.totalRejeitados ?? 0),
+      })),
     };
   }
 
@@ -919,15 +915,6 @@ export class DashboardService {
     ]);
 
     return {
-      /*  geral: {
-        solicitacoesEmAberto: geral.solicitacoesEmAberto,
-        solicitacoesConcluidas: geral.solicitacoesConcluidas,
-        documentosPendentesValidacao: geral.documentosPendentesValidacao,
-        clientesNovosMesAtual: geral.clientesNovosMesAtual,
-        taxaCancelamentoPct: geral.taxaCancelamentoPct,
-        debitosEmAberto: geral.debitosEmAberto,
-        parcelasVencidasNaoPagas: geral.parcelasVencidasNaoPagas,
-      }, */
       geral,
       solicitacoes,
       servicos,

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -19,6 +19,7 @@ import {
   VeiculosDto,
   ServicosDto,
   FinanceiroDto,
+  ClientesDashboardDto,
 } from './dto/dashboard-return.dto';
 import type { ModelCtor } from 'sequelize-typescript';
 import type {
@@ -33,6 +34,9 @@ import type {
   ParcelasVencidasRaw,
   TempoConclusaoRaw,
   DebitoVeiculoRaw,
+  TopClienteVolumeRaw,
+  TopClienteValorPagoRaw,
+  ClienteParcelaAtrasoRaw,
 } from './dashboard.types';
 import { MaisSolicitadosRow, ReceitaPorServicoRow } from './dashboard.types';
 
@@ -677,18 +681,158 @@ export class DashboardService {
     };
   }
 
+  async obterDadosClientes(
+    inicio?: string,
+    fim?: string,
+  ): Promise<ClientesDashboardDto> {
+    const { dataInicio, dataFim } = this.converterData(inicio, fim);
+    const hoje = new Date();
+    const [topPorVolumeRaw, topPorValorPagoRaw, comParcelasEmAtrasoRaw] =
+      await Promise.all([
+        this.solicitacaoModel.findAll({
+          attributes: [
+            [col('Solicitacao.usuario_id'), 'usuarioId'],
+            [col('usuario.nome'), 'nome'],
+            [fn('COUNT', col('Solicitacao.id')), 'totalSolicitacoes'],
+          ],
+          include: [{ model: Usuario, attributes: [], required: true }],
+          where: {
+            dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+          },
+          group: [
+            col('Solicitacao.usuario_id'),
+            col('usuario.id'),
+            col('usuario.nome'),
+          ],
+          order: [[literal('totalSolicitacoes'), 'DESC']],
+          limit: 5,
+          raw: true,
+        }) as unknown as Promise<TopClienteVolumeRaw[]>,
+
+        this.debitoVeiculoModel.findAll({
+          attributes: [
+            [col('veiculo.usuario_id'), 'usuarioId'],
+            [col('veiculo->usuario.nome'), 'nome'],
+            [fn('SUM', col('debito.valor')), 'valorTotalPago'],
+          ],
+          include: [
+            {
+              model: Debito,
+              attributes: [],
+              required: true,
+              where: {
+                status: 'pago',
+                createdAt: { [Op.between]: [dataInicio, dataFim] },
+              },
+            },
+            {
+              model: Veiculo,
+              attributes: [],
+              required: true,
+              include: [{ model: Usuario, attributes: [], required: true }],
+            },
+          ],
+          group: [
+            col('veiculo.usuario_id'),
+            col('veiculo->usuario.id'),
+            col('veiculo->usuario.nome'),
+          ],
+          order: [[literal('valorTotalPago'), 'DESC']],
+          limit: 5,
+          raw: true,
+        }) as unknown as Promise<TopClienteValorPagoRaw[]>,
+
+        this.debitoVeiculoModel.findAll({
+          attributes: [
+            [col('veiculo.usuario_id'), 'usuarioId'],
+            [col('veiculo->usuario.nome'), 'nome'],
+            [
+              fn('COUNT', col('debito->pagamento->parcelas.id')),
+              'quantidadeParcelasAtrasadas',
+            ],
+            [
+              fn('SUM', col('debito->pagamento->parcelas.valor')),
+              'valorTotalAtrasado',
+            ],
+          ],
+          include: [
+            {
+              model: Debito,
+              attributes: [],
+              required: true,
+              include: [
+                {
+                  model: Pagamento,
+                  attributes: [],
+                  required: true,
+                  include: [
+                    {
+                      model: Parcela,
+                      attributes: [],
+                      required: true,
+                      where: {
+                        vencimento: { [Op.lt]: hoje },
+                        status: { [Op.ne]: 'pago' },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              model: Veiculo,
+              attributes: [],
+              required: true,
+              include: [{ model: Usuario, attributes: [], required: true }],
+            },
+          ],
+          group: [
+            col('veiculo.usuario_id'),
+            col('veiculo->usuario.id'),
+            col('veiculo->usuario.nome'),
+          ],
+          order: [[literal('quantidadeParcelasAtrasadas'), 'DESC']],
+          raw: true,
+        }) as unknown as Promise<ClienteParcelaAtrasoRaw[]>,
+      ]);
+
+    return {
+      clientes: {
+        topPorVolume: topPorVolumeRaw.map((item) => ({
+          usuarioId: Number(item.usuarioId),
+          nome: item.nome,
+          totalSolicitacoes: Number(item.totalSolicitacoes ?? 0),
+        })),
+        topPorValorPago: topPorValorPagoRaw.map((item) => ({
+          usuarioId: Number(item.usuarioId),
+          nome: item.nome,
+          valorTotalPago: Number(item.valorTotalPago ?? 0),
+        })),
+        comParcelasEmAtraso: comParcelasEmAtrasoRaw.map((item) => ({
+          usuarioId: Number(item.usuarioId),
+          nome: item.nome,
+          quantidadeParcelasAtrasadas: Number(
+            item.quantidadeParcelasAtrasadas ?? 0,
+          ),
+          valorTotalAtrasado: Number(item.valorTotalAtrasado ?? 0),
+        })),
+      },
+    };
+  }
+
   /** Função principal que orquestra o retorno geral do dashboard */
   async retornoTotalDashboard(
     inicioParam?: string,
     fimParam?: string,
   ): Promise<DashboardReturnDto> {
-    const [geral, solicitacoes, veiculos, servicos, financeiro] =
+    const [geral, solicitacoes, veiculos, servicos, financeiro, clientes] =
       await Promise.all([
         this.obterDadosGerais(inicioParam, fimParam),
         this.obterDadosSolicitacoes(inicioParam, fimParam),
         this.obterDadosVeiculos(),
         this.obterDadosServicos(inicioParam, fimParam),
         this.obterDadosFinanceiro(inicioParam, fimParam),
+        this.obterDadosClientes(inicioParam, fimParam),
       ]);
 
     return {
@@ -705,6 +849,7 @@ export class DashboardService {
       servicos,
       financeiro,
       veiculos,
+      clientes,
     };
   }
 }

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -20,6 +20,7 @@ import {
   ServicosDto,
   FinanceiroDto,
   ClientesDashboardDto,
+  DocumentosDashboardDto,
 } from './dto/dashboard-return.dto';
 import type { ModelCtor } from 'sequelize-typescript';
 import type {
@@ -37,6 +38,8 @@ import type {
   TopClienteVolumeRaw,
   TopClienteValorPagoRaw,
   ClienteParcelaAtrasoRaw,
+  RejeicaoPorTipoRaw,
+  DocumentoStatusRaw,
 } from './dashboard.types';
 import { MaisSolicitadosRow, ReceitaPorServicoRow } from './dashboard.types';
 
@@ -820,23 +823,103 @@ export class DashboardService {
     };
   }
 
+  async obterDadosDocumentos(
+    inicio?: string,
+    fim?: string,
+  ): Promise<DocumentosDashboardDto> {
+    const { dataInicio, dataFim } = this.converterData(inicio, fim);
+
+    const [
+      pendentes,
+      aprovadosRejeitadosRaw,
+      solicitacoesTravadas,
+      rejeicoesPorTipoRaw,
+    ] = await Promise.all([
+      this.documentoSolicitacaoModel.count({
+        where: { statusValidacao: 'pendente' },
+      }),
+
+      this.documentoSolicitacaoModel.findAll({
+        attributes: [
+          'statusValidacao',
+          [fn('COUNT', col('DocumentoSolicitacao.id')), 'quantidade'],
+        ],
+        where: {
+          statusValidacao: { [Op.in]: ['aprovado', 'rejeitado'] },
+          dataUpload: { [Op.between]: [dataInicio, dataFim] },
+        },
+        group: [col('DocumentoSolicitacao.status_validacao')],
+        raw: true,
+      }) as unknown as Promise<DocumentoStatusRaw[]>,
+
+      this.solicitacaoModel.count({
+        where: {
+          status: 'aguardando_documento',
+          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
+        },
+      }),
+
+      this.documentoSolicitacaoModel.findAll({
+        attributes: [
+          'tipoDocumento',
+          [fn('COUNT', col('DocumentoSolicitacao.id')), 'totalRejeitados'],
+        ],
+        where: {
+          statusValidacao: 'rejeitado',
+          dataUpload: { [Op.between]: [dataInicio, dataFim] },
+        },
+        group: [col('DocumentoSolicitacao.tipo_documento')],
+        order: [[literal('totalRejeitados'), 'DESC']],
+        raw: true,
+      }) as unknown as Promise<RejeicaoPorTipoRaw[]>,
+    ]);
+
+    const aprovados = aprovadosRejeitadosRaw.find(
+      (item) => item.statusValidacao === 'aprovado',
+    );
+    const rejeitados = aprovadosRejeitadosRaw.find(
+      (item) => item.statusValidacao === 'rejeitado',
+    );
+
+    return {
+      documentos: {
+        pendentes: Number(pendentes ?? 0),
+        aprovados: Number(aprovados?.quantidade ?? 0),
+        rejeitados: Number(rejeitados?.quantidade ?? 0),
+        solicitacoesTravadas: Number(solicitacoesTravadas ?? 0),
+        rejeicoesPorTipo: rejeicoesPorTipoRaw.map((item) => ({
+          tipoDocumento: item.tipoDocumento ?? 'nao_informado',
+          totalRejeitados: Number(item.totalRejeitados ?? 0),
+        })),
+      },
+    };
+  }
+
   /** Função principal que orquestra o retorno geral do dashboard */
   async retornoTotalDashboard(
     inicioParam?: string,
     fimParam?: string,
   ): Promise<DashboardReturnDto> {
-    const [geral, solicitacoes, veiculos, servicos, financeiro, clientes] =
-      await Promise.all([
-        this.obterDadosGerais(inicioParam, fimParam),
-        this.obterDadosSolicitacoes(inicioParam, fimParam),
-        this.obterDadosVeiculos(),
-        this.obterDadosServicos(inicioParam, fimParam),
-        this.obterDadosFinanceiro(inicioParam, fimParam),
-        this.obterDadosClientes(inicioParam, fimParam),
-      ]);
+    const [
+      geral,
+      solicitacoes,
+      veiculos,
+      servicos,
+      financeiro,
+      documentos,
+      clientes,
+    ] = await Promise.all([
+      this.obterDadosGerais(inicioParam, fimParam),
+      this.obterDadosSolicitacoes(inicioParam, fimParam),
+      this.obterDadosVeiculos(),
+      this.obterDadosServicos(inicioParam, fimParam),
+      this.obterDadosFinanceiro(inicioParam, fimParam),
+      this.obterDadosDocumentos(inicioParam, fimParam),
+      this.obterDadosClientes(inicioParam, fimParam),
+    ]);
 
     return {
-      geral: {
+      /*  geral: {
         solicitacoesEmAberto: geral.solicitacoesEmAberto,
         solicitacoesConcluidas: geral.solicitacoesConcluidas,
         documentosPendentesValidacao: geral.documentosPendentesValidacao,
@@ -844,11 +927,13 @@ export class DashboardService {
         taxaCancelamentoPct: geral.taxaCancelamentoPct,
         debitosEmAberto: geral.debitosEmAberto,
         parcelasVencidasNaoPagas: geral.parcelasVencidasNaoPagas,
-      },
+      }, */
+      geral,
       solicitacoes,
       servicos,
       financeiro,
       veiculos,
+      documentos,
       clientes,
     };
   }

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -716,7 +716,7 @@ export class DashboardService {
           attributes: [
             [col('veiculo.usuario_id'), 'usuarioId'],
             [col('veiculo->usuario.nome'), 'nome'],
-            [fn('SUM', col('debito.valor')), 'valorTotalPago'],
+            [fn('SUM', col('debito->pagamento.valor_total')), 'valorTotalPago'],
           ],
           include: [
             {
@@ -725,8 +725,17 @@ export class DashboardService {
               required: true,
               where: {
                 status: 'pago',
-                createdAt: { [Op.between]: [dataInicio, dataFim] },
               },
+              include: [
+                {
+                  model: Pagamento,
+                  attributes: [],
+                  required: true,
+                  where: {
+                    createdAt: { [Op.between]: [dataInicio, dataFim] },
+                  },
+                },
+              ],
             },
             {
               model: Veiculo,
@@ -853,7 +862,6 @@ export class DashboardService {
       this.solicitacaoModel.count({
         where: {
           status: 'aguardando_documento',
-          dataSolicitacao: { [Op.between]: [dataInicio, dataFim] },
         },
       }),
 

--- a/src/modules/dashboard/dashboard.types.ts
+++ b/src/modules/dashboard/dashboard.types.ts
@@ -63,6 +63,25 @@ export interface DebitoVeiculoRaw {
   veiculo: { placa: string };
 }
 
+export interface TopClienteVolumeRaw {
+  usuarioId: number | string;
+  nome: string;
+  totalSolicitacoes: number | string;
+}
+
+export interface TopClienteValorPagoRaw {
+  usuarioId: number | string;
+  nome: string;
+  valorTotalPago: number | string;
+}
+
+export interface ClienteParcelaAtrasoRaw {
+  usuarioId: number | string;
+  nome: string;
+  quantidadeParcelasAtrasadas: number | string;
+  valorTotalAtrasado: number | string;
+}
+
 export type MaisSolicitadosRow = Solicitacao & {
   servico?: Servico;
   get(key: 'servicoId' | 'totalSolicitacoes'): string | number | null;

--- a/src/modules/dashboard/dashboard.types.ts
+++ b/src/modules/dashboard/dashboard.types.ts
@@ -82,6 +82,16 @@ export interface ClienteParcelaAtrasoRaw {
   valorTotalAtrasado: number | string;
 }
 
+export interface DocumentoStatusRaw {
+  statusValidacao: 'aprovado' | 'rejeitado';
+  quantidade: number | string;
+}
+
+export interface RejeicaoPorTipoRaw {
+  tipoDocumento: string | null;
+  totalRejeitados: number | string;
+}
+
 export type MaisSolicitadosRow = Solicitacao & {
   servico?: Servico;
   get(key: 'servicoId' | 'totalSolicitacoes'): string | number | null;

--- a/src/modules/dashboard/dto/dashboard-return.dto.ts
+++ b/src/modules/dashboard/dto/dashboard-return.dto.ts
@@ -121,10 +121,40 @@ export class GeralDto {
   };
 }
 
+export class ClienteTopPorVolumeDto {
+  usuarioId!: number;
+  nome!: string;
+  totalSolicitacoes!: number;
+}
+
+export class ClienteTopPorValorPagoDto {
+  usuarioId!: number;
+  nome!: string;
+  valorTotalPago!: number;
+}
+
+export class ClienteComParcelasEmAtrasoDto {
+  usuarioId!: number;
+  nome!: string;
+  quantidadeParcelasAtrasadas!: number;
+  valorTotalAtrasado!: number;
+}
+
+export class ClientesDto {
+  topPorVolume!: ClienteTopPorVolumeDto[];
+  topPorValorPago!: ClienteTopPorValorPagoDto[];
+  comParcelasEmAtraso!: ClienteComParcelasEmAtrasoDto[];
+}
+
+export class ClientesDashboardDto {
+  clientes!: ClientesDto;
+}
+
 export class DashboardReturnDto {
   geral!: GeralDto;
   solicitacoes!: SolicitacoesDto;
   financeiro!: FinanceiroDto;
   servicos!: ServicosDto;
   veiculos!: VeiculosDto;
+  clientes!: ClientesDashboardDto;
 }

--- a/src/modules/dashboard/dto/dashboard-return.dto.ts
+++ b/src/modules/dashboard/dto/dashboard-return.dto.ts
@@ -150,6 +150,23 @@ export class ClientesDashboardDto {
   clientes!: ClientesDto;
 }
 
+export class RejeicaoPorTipoDocumentoDto {
+  tipoDocumento!: string;
+  totalRejeitados!: number;
+}
+
+export class DocumentosDto {
+  pendentes!: number;
+  aprovados!: number;
+  rejeitados!: number;
+  solicitacoesTravadas!: number;
+  rejeicoesPorTipo!: RejeicaoPorTipoDocumentoDto[];
+}
+
+export class DocumentosDashboardDto {
+  documentos!: DocumentosDto;
+}
+
 export class DashboardReturnDto {
   geral!: GeralDto;
   solicitacoes!: SolicitacoesDto;
@@ -157,4 +174,5 @@ export class DashboardReturnDto {
   servicos!: ServicosDto;
   veiculos!: VeiculosDto;
   clientes!: ClientesDashboardDto;
+  documentos!: DocumentosDashboardDto;
 }

--- a/src/modules/dashboard/dto/dashboard-return.dto.ts
+++ b/src/modules/dashboard/dto/dashboard-return.dto.ts
@@ -146,10 +146,6 @@ export class ClientesDto {
   comParcelasEmAtraso!: ClienteComParcelasEmAtrasoDto[];
 }
 
-export class ClientesDashboardDto {
-  clientes!: ClientesDto;
-}
-
 export class RejeicaoPorTipoDocumentoDto {
   tipoDocumento!: string;
   totalRejeitados!: number;
@@ -163,16 +159,12 @@ export class DocumentosDto {
   rejeicoesPorTipo!: RejeicaoPorTipoDocumentoDto[];
 }
 
-export class DocumentosDashboardDto {
-  documentos!: DocumentosDto;
-}
-
 export class DashboardReturnDto {
   geral!: GeralDto;
   solicitacoes!: SolicitacoesDto;
   financeiro!: FinanceiroDto;
   servicos!: ServicosDto;
   veiculos!: VeiculosDto;
-  clientes!: ClientesDashboardDto;
-  documentos!: DocumentosDashboardDto;
+  clientes!: ClientesDto;
+  documentos!: DocumentosDto;
 }


### PR DESCRIPTION
# Esse PR implementa os blocos restantes dentro do dashboard:
(Tanto as queries quanto os endpoints)

## Retorno de Exemplo:

```json
"documentos": {
        "documentos": {
            "pendentes": 4,
            "aprovados": 3,
            "rejeitados": 0,
            "solicitacoesTravadas": 1,
            "rejeicoesPorTipo": []
        }
    },
    "clientes": {
        "clientes": {
            "topPorVolume": [
                {
                    "usuarioId": 2,
                    "nome": "Bruno Costa",
                    "totalSolicitacoes": 10
                },
                {
                    "usuarioId": 1,
                    "nome": "Ana Martins",
                    "totalSolicitacoes": 6
                },
                {
                    "usuarioId": 3,
                    "nome": "Carla Souza",
                    "totalSolicitacoes": 3
                },
                {
                    "usuarioId": 5,
                    "nome": "Eduardo Rocha",
                    "totalSolicitacoes": 1
                },
                {
                    "usuarioId": 4,
                    "nome": "Daniel Lima",
                    "totalSolicitacoes": 1
                }
            ],
            "topPorValorPago": [
                {
                    "usuarioId": 2,
                    "nome": "Bruno Costa",
                    "valorTotalPago": 270
                },
                {
                    "usuarioId": 5,
                    "nome": "Eduardo Rocha",
                    "valorTotalPago": 170
                }
            ],
            "comParcelasEmAtraso": [
                {
                    "usuarioId": 2,
                    "nome": "Bruno Costa",
                    "quantidadeParcelasAtrasadas": 1,
                    "valorTotalAtrasado": 125
                }
            ]
        }
    }

```

closes #165 
closes #167 