### PR TITLE
Fix busca simples servico usuario publicidade

### DIFF
--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
-import { col, fn, Op, where } from 'sequelize';
+import { cast, col, fn, Op, where } from 'sequelize';
 import { Banner } from 'src/models/banner.model';
 import { Blog } from 'src/models/blog.model';
 import { Empresa } from 'src/models/empresa.model';
@@ -23,7 +23,7 @@ export class BuscaService {
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
     @InjectModel(Empresa) private empresaModel: typeof Empresa,
-  ) {}
+  ) { }
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,
@@ -63,10 +63,18 @@ export class BuscaService {
   ): Promise<Servico[]> {
     const filtros = [
       ...(dto.valor_base !== undefined
-        ? [where(col('valor_base'), Op.eq, dto.valor_base)]
+        ? [
+          where(cast(col('valor_base'), 'TEXT'), {
+            [Op.like]: `%${String(dto.valor_base)}%`,
+          }),
+        ]
         : []),
       ...(dto.prazo_estimado !== undefined
-        ? [where(col('prazo_estimado_dias'), Op.eq, dto.prazo_estimado)]
+        ? [
+          where(cast(col('prazo_estimado_dias'), 'TEXT'), {
+            [Op.like]: `%${String(dto.prazo_estimado)}%`,
+          }),
+        ]
         : []),
       ...(dto.status
         ? [where(col('ativo'), Op.eq, dto.status === 'ativo')]
@@ -361,56 +369,50 @@ export class BuscaService {
       };
     }
 
-    const idExtraido = this.extrairIdExato(termoNormalizado);
-    const buscaIdExplicita = this.termoRepresentaIdExplicito(termoNormalizado);
-
-    if (idExtraido !== undefined) {
-      const itensPorId = await this.publicidadeModel.findAll({
-        where: { id: idExtraido },
-        order: [['id', 'DESC']],
-      });
-
-      if (itensPorId.length > 0 || buscaIdExplicita) {
-        return {
-          itens: itensPorId,
-          mensagem:
-            itensPorId.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
-        };
-      }
-    }
-
     const filtros: Array<Record<string, unknown>> = [
+      { titulo: { [Op.like]: `%${termoNormalizado}%` } },
       { urlImagem: { [Op.like]: `%${termoNormalizado}%` } },
       { conteudo: { [Op.like]: `%${termoNormalizado}%` } },
+      where(cast(col('id'), 'TEXT'), {
+        [Op.like]: `%${termoNormalizado}%`,
+      }) as unknown as Record<string, unknown>,
     ];
 
-    const itens = await this.publicidadeModel.findAll({
+    const itensDiretos = await this.publicidadeModel.findAll({
       where: { [Op.or]: filtros },
       order: [['id', 'DESC']],
+    });
+
+    if (itensDiretos.length > 0) {
+      return {
+        itens: itensDiretos,
+        mensagem: undefined,
+      };
+    }
+
+    const termoSemAcento = this.normalizarTextoBusca(termoNormalizado);
+    const todos = await this.publicidadeModel.findAll({
+      order: [['id', 'DESC']],
+    });
+
+    const itens = todos.filter((item) => {
+      const titulo = this.normalizarTextoBusca(item.titulo ?? '');
+      const conteudo = this.normalizarTextoBusca(item.conteudo ?? '');
+      const urlImagem = this.normalizarTextoBusca(item.urlImagem ?? '');
+      const id = String(item.id);
+
+      return (
+        titulo.includes(termoSemAcento) ||
+        conteudo.includes(termoSemAcento) ||
+        urlImagem.includes(termoSemAcento) ||
+        id.includes(termoSemAcento)
+      );
     });
 
     return {
       itens,
       mensagem: itens.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
     };
-  }
-
-  private extrairIdExato(valor: string): number | undefined {
-    const valorNumerico = valor.match(/^(0|[1-9]\d*)$/);
-    if (valorNumerico) {
-      return parseInt(valorNumerico[1], 10);
-    }
-
-    const valorComPrefixoId = valor.match(/^id\s*[:#-]?\s*(0|[1-9]\d*)$/i);
-    if (valorComPrefixoId) {
-      return parseInt(valorComPrefixoId[1], 10);
-    }
-
-    return undefined;
-  }
-
-  private termoRepresentaIdExplicito(valor: string): boolean {
-    return /^id\s*[:#-]?\s*(0|[1-9]\d*)$/i.test(valor);
   }
 
   async listarUsuariosByTermo(termo?: string): Promise<{
@@ -439,11 +441,72 @@ export class BuscaService {
       { celular: { [Op.like]: `%${termoNormalizado}%` } },
     ];
 
+    const filtrosData: Array<ReturnType<typeof where>> = [];
     const dataNormalizada = this.normalizarDataBusca(termoNormalizado);
     if (dataNormalizada) {
       const inicio = new Date(`${dataNormalizada}T00:00:00.000Z`);
       const fim = new Date(`${dataNormalizada}T23:59:59.999Z`);
-      filtros.push(where(col('data_cadastro'), Op.between, [inicio, fim]));
+      filtrosData.push(where(col('data_cadastro'), Op.between, [inicio, fim]));
+    }
+
+    const dataParcialNormalizada = this.normalizarDataBuscaParcial(
+      termoNormalizado,
+    );
+    if (dataParcialNormalizada) {
+      filtrosData.push(
+        where(cast(fn('DATE', col('data_cadastro')), 'TEXT'), {
+          [Op.like]: `%${dataParcialNormalizada}%`,
+        }),
+      );
+    }
+
+    if (/\d/.test(termoNormalizado)) {
+      const termoNumericoData = this.extrairFragmentoNumericoData(
+        termoNormalizado,
+      );
+      if (termoNumericoData) {
+        filtrosData.push(
+          where(
+            fn(
+              'REPLACE',
+              cast(fn('DATE', col('data_cadastro')), 'TEXT'),
+              '-',
+              '',
+            ),
+            {
+              [Op.like]: `%${termoNumericoData}%`,
+            },
+          ),
+        );
+      }
+    }
+
+    const termoEhApenasDigitosOuSeparadores = /^[\d/\-\s]+$/.test(
+      termoNormalizado,
+    );
+
+    if (termoEhApenasDigitosOuSeparadores && filtrosData.length > 0) {
+      const itensPorData = await this.usuarioModel.findAll({
+        attributes: { exclude: ['senha'] },
+        where: { [Op.or]: filtrosData },
+        order: [['id', 'DESC']],
+      });
+
+      if (itensPorData.length > 0) {
+        return {
+          itens: itensPorData,
+          mensagem: undefined,
+        };
+      }
+    }
+
+    if (/\d/.test(termoNormalizado)) {
+      filtros.push(
+        where(cast(col('id'), 'TEXT'), {
+          [Op.like]: `%${termoNormalizado}%`,
+        }),
+      );
+      filtros.push(...filtrosData);
     }
 
     const itens = await this.usuarioModel.findAll({
@@ -481,22 +544,22 @@ export class BuscaService {
       { descricao: { [Op.like]: `%${termoNormalizado}%` } },
     ];
 
-    const termoEhNumero = /^(0|[1-9]\d*)(\.\d+)?$/.test(termoNormalizado);
-    if (termoEhNumero) {
-      const termoComoNumero = Number(termoNormalizado);
-      if (!Number.isNaN(termoComoNumero)) {
-        filtros.push(where(col('valor_base'), Op.eq, termoComoNumero));
-      }
-    }
-
-    const termoEhInteiroDecimal = /^(0|[1-9]\d*)$/.test(termoNormalizado);
-    if (termoEhInteiroDecimal) {
-      const termoComoInteiro = parseInt(termoNormalizado, 10);
-      if (!Number.isNaN(termoComoInteiro)) {
-        filtros.push(
-          where(col('prazo_estimado_dias'), Op.eq, termoComoInteiro),
-        );
-      }
+    if (/\d/.test(termoNormalizado)) {
+      filtros.push(
+        where(cast(col('valor_base'), 'TEXT'), {
+          [Op.like]: `%${termoNormalizado}%`,
+        }),
+      );
+      filtros.push(
+        where(cast(col('prazo_estimado_dias'), 'TEXT'), {
+          [Op.like]: `%${termoNormalizado}%`,
+        }),
+      );
+      filtros.push(
+        where(cast(col('id'), 'TEXT'), {
+          [Op.like]: `%${termoNormalizado}%`,
+        }),
+      );
     }
 
     const itens = await this.servicoModel.findAll({
@@ -534,6 +597,25 @@ export class BuscaService {
     return undefined;
   }
 
+  private normalizarDataBuscaParcial(valor: string): string | undefined {
+    const termo = valor.trim();
+    if (!termo || !/[\d/\-]/.test(termo)) {
+      return undefined;
+    }
+
+    const somenteData = termo.replace(/[^\d/\-]/g, '');
+    if (!somenteData || !/[\/-]/.test(somenteData)) {
+      return undefined;
+    }
+
+    return somenteData.replace(/\//g, '-');
+  }
+
+  private extrairFragmentoNumericoData(valor: string): string | undefined {
+    const numeros = valor.replace(/\D/g, '');
+    return numeros.length > 0 ? numeros : undefined;
+  }
+
   private validarData(ano: number, mes: number, dia: number): boolean {
     const dataUtc = new Date(Date.UTC(ano, mes - 1, dia, 0, 0, 0, 0));
     return (
@@ -541,5 +623,12 @@ export class BuscaService {
       dataUtc.getUTCMonth() === mes - 1 &&
       dataUtc.getUTCDate() === dia
     );
+  }
+
+  private normalizarTextoBusca(valor: string): string {
+    return valor
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase();
   }
 }

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -23,7 +23,7 @@ export class BuscaService {
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
     @InjectModel(Empresa) private empresaModel: typeof Empresa,
-  ) { }
+  ) {}
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,
@@ -64,17 +64,17 @@ export class BuscaService {
     const filtros = [
       ...(dto.valor_base !== undefined
         ? [
-          where(cast(col('valor_base'), 'TEXT'), {
-            [Op.like]: `%${String(dto.valor_base)}%`,
-          }),
-        ]
+            where(cast(col('valor_base'), 'TEXT'), {
+              [Op.like]: `%${String(dto.valor_base)}%`,
+            }),
+          ]
         : []),
       ...(dto.prazo_estimado !== undefined
         ? [
-          where(cast(col('prazo_estimado_dias'), 'TEXT'), {
-            [Op.like]: `%${String(dto.prazo_estimado)}%`,
-          }),
-        ]
+            where(cast(col('prazo_estimado_dias'), 'TEXT'), {
+              [Op.like]: `%${String(dto.prazo_estimado)}%`,
+            }),
+          ]
         : []),
       ...(dto.status
         ? [where(col('ativo'), Op.eq, dto.status === 'ativo')]

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -23,7 +23,7 @@ export class BuscaService {
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
     @InjectModel(Empresa) private empresaModel: typeof Empresa,
-  ) { }
+  ) {}
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,
@@ -64,17 +64,17 @@ export class BuscaService {
     const filtros = [
       ...(dto.valor_base !== undefined
         ? [
-          where(cast(col('valor_base'), 'TEXT'), {
-            [Op.like]: `%${String(dto.valor_base)}%`,
-          }),
-        ]
+            where(cast(col('valor_base'), 'TEXT'), {
+              [Op.like]: `%${String(dto.valor_base)}%`,
+            }),
+          ]
         : []),
       ...(dto.prazo_estimado !== undefined
         ? [
-          where(cast(col('prazo_estimado_dias'), 'TEXT'), {
-            [Op.like]: `%${String(dto.prazo_estimado)}%`,
-          }),
-        ]
+            where(cast(col('prazo_estimado_dias'), 'TEXT'), {
+              [Op.like]: `%${String(dto.prazo_estimado)}%`,
+            }),
+          ]
         : []),
       ...(dto.status
         ? [where(col('ativo'), Op.eq, dto.status === 'ativo')]
@@ -449,9 +449,8 @@ export class BuscaService {
       filtrosData.push(where(col('data_cadastro'), Op.between, [inicio, fim]));
     }
 
-    const dataParcialNormalizada = this.normalizarDataBuscaParcial(
-      termoNormalizado,
-    );
+    const dataParcialNormalizada =
+      this.normalizarDataBuscaParcial(termoNormalizado);
     if (dataParcialNormalizada) {
       filtrosData.push(
         where(cast(fn('DATE', col('data_cadastro')), 'TEXT'), {
@@ -461,9 +460,8 @@ export class BuscaService {
     }
 
     if (/\d/.test(termoNormalizado)) {
-      const termoNumericoData = this.extrairFragmentoNumericoData(
-        termoNormalizado,
-      );
+      const termoNumericoData =
+        this.extrairFragmentoNumericoData(termoNormalizado);
       if (termoNumericoData) {
         filtrosData.push(
           where(
@@ -599,12 +597,12 @@ export class BuscaService {
 
   private normalizarDataBuscaParcial(valor: string): string | undefined {
     const termo = valor.trim();
-    if (!termo || !/[\d/\-]/.test(termo)) {
+    if (!termo || !/[\d/-]/.test(termo)) {
       return undefined;
     }
 
-    const somenteData = termo.replace(/[^\d/\-]/g, '');
-    if (!somenteData || !/[\/-]/.test(somenteData)) {
+    const somenteData = termo.replace(/[^\d/-]/g, '');
+    if (!somenteData || !/[/-]/.test(somenteData)) {
       return undefined;
     }
 

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -23,7 +23,7 @@ export class BuscaService {
     @InjectModel(Publicidade) private publicidadeModel: typeof Publicidade,
     @InjectModel(Usuario) private usuarioModel: typeof Usuario,
     @InjectModel(Empresa) private empresaModel: typeof Empresa,
-  ) {}
+  ) { }
 
   async buscarBlogsPorIntervaloDeData(
     dto: BuscaBlogIntervaloDto,
@@ -64,17 +64,17 @@ export class BuscaService {
     const filtros = [
       ...(dto.valor_base !== undefined
         ? [
-            where(cast(col('valor_base'), 'TEXT'), {
-              [Op.like]: `%${String(dto.valor_base)}%`,
-            }),
-          ]
+          where(cast(col('valor_base'), 'TEXT'), {
+            [Op.like]: `%${String(dto.valor_base)}%`,
+          }),
+        ]
         : []),
       ...(dto.prazo_estimado !== undefined
         ? [
-            where(cast(col('prazo_estimado_dias'), 'TEXT'), {
-              [Op.like]: `%${String(dto.prazo_estimado)}%`,
-            }),
-          ]
+          where(cast(col('prazo_estimado_dias'), 'TEXT'), {
+            [Op.like]: `%${String(dto.prazo_estimado)}%`,
+          }),
+        ]
         : []),
       ...(dto.status
         ? [where(col('ativo'), Op.eq, dto.status === 'ativo')]

--- a/src/modules/busca/busca.service.ts
+++ b/src/modules/busca/busca.service.ts
@@ -369,44 +369,32 @@ export class BuscaService {
       };
     }
 
-    const filtros: Array<Record<string, unknown>> = [
-      { titulo: { [Op.like]: `%${termoNormalizado}%` } },
-      { urlImagem: { [Op.like]: `%${termoNormalizado}%` } },
-      { conteudo: { [Op.like]: `%${termoNormalizado}%` } },
-      where(cast(col('id'), 'TEXT'), {
-        [Op.like]: `%${termoNormalizado}%`,
-      }) as unknown as Record<string, unknown>,
-    ];
+    const idExato = this.extrairIdExatoDoTermo(termoNormalizado);
 
-    const itensDiretos = await this.publicidadeModel.findAll({
-      where: { [Op.or]: filtros },
-      order: [['id', 'DESC']],
-    });
+    if (idExato !== undefined) {
+      const itensPorId = await this.publicidadeModel.findAll({
+        where: { id: idExato },
+        order: [['id', 'DESC']],
+      });
 
-    if (itensDiretos.length > 0) {
-      return {
-        itens: itensDiretos,
-        mensagem: undefined,
-      };
+      const termoNoFormatoId = /^id\s+\d+$/i.test(termoNormalizado);
+      if (itensPorId.length > 0 || termoNoFormatoId) {
+        return {
+          itens: itensPorId,
+          mensagem:
+            itensPorId.length === 0 ? 'Nenhum item foi encontrado.' : undefined,
+        };
+      }
     }
 
-    const termoSemAcento = this.normalizarTextoBusca(termoNormalizado);
-    const todos = await this.publicidadeModel.findAll({
+    const itens = await this.publicidadeModel.findAll({
+      where: {
+        [Op.or]: [
+          { urlImagem: { [Op.like]: `%${termoNormalizado}%` } },
+          { conteudo: { [Op.like]: `%${termoNormalizado}%` } },
+        ],
+      },
       order: [['id', 'DESC']],
-    });
-
-    const itens = todos.filter((item) => {
-      const titulo = this.normalizarTextoBusca(item.titulo ?? '');
-      const conteudo = this.normalizarTextoBusca(item.conteudo ?? '');
-      const urlImagem = this.normalizarTextoBusca(item.urlImagem ?? '');
-      const id = String(item.id);
-
-      return (
-        titulo.includes(termoSemAcento) ||
-        conteudo.includes(termoSemAcento) ||
-        urlImagem.includes(termoSemAcento) ||
-        id.includes(termoSemAcento)
-      );
     });
 
     return {
@@ -441,70 +429,29 @@ export class BuscaService {
       { celular: { [Op.like]: `%${termoNormalizado}%` } },
     ];
 
-    const filtrosData: Array<ReturnType<typeof where>> = [];
     const dataNormalizada = this.normalizarDataBusca(termoNormalizado);
     if (dataNormalizada) {
       const inicio = new Date(`${dataNormalizada}T00:00:00.000Z`);
       const fim = new Date(`${dataNormalizada}T23:59:59.999Z`);
-      filtrosData.push(where(col('data_cadastro'), Op.between, [inicio, fim]));
-    }
-
-    const dataParcialNormalizada =
-      this.normalizarDataBuscaParcial(termoNormalizado);
-    if (dataParcialNormalizada) {
-      filtrosData.push(
-        where(cast(fn('DATE', col('data_cadastro')), 'TEXT'), {
-          [Op.like]: `%${dataParcialNormalizada}%`,
-        }),
-      );
-    }
-
-    if (/\d/.test(termoNormalizado)) {
-      const termoNumericoData =
-        this.extrairFragmentoNumericoData(termoNormalizado);
-      if (termoNumericoData) {
-        filtrosData.push(
-          where(
-            fn(
-              'REPLACE',
-              cast(fn('DATE', col('data_cadastro')), 'TEXT'),
-              '-',
-              '',
-            ),
-            {
-              [Op.like]: `%${termoNumericoData}%`,
-            },
-          ),
+      filtros.push(where(col('data_cadastro'), Op.between, [inicio, fim]));
+    } else {
+      const dataParcialNormalizada =
+        this.normalizarDataBuscaParcial(termoNormalizado);
+      if (dataParcialNormalizada) {
+        filtros.push(
+          where(cast(fn('DATE', col('data_cadastro')), 'TEXT'), {
+            [Op.like]: `%${dataParcialNormalizada}%`,
+          }),
         );
       }
     }
 
-    const termoEhApenasDigitosOuSeparadores = /^[\d/\-\s]+$/.test(
-      termoNormalizado,
-    );
-
-    if (termoEhApenasDigitosOuSeparadores && filtrosData.length > 0) {
-      const itensPorData = await this.usuarioModel.findAll({
-        attributes: { exclude: ['senha'] },
-        where: { [Op.or]: filtrosData },
-        order: [['id', 'DESC']],
-      });
-
-      if (itensPorData.length > 0) {
-        return {
-          itens: itensPorData,
-          mensagem: undefined,
-        };
-      }
-    }
-
-    if (/\d/.test(termoNormalizado)) {
+    if (/\d/.test(termoNormalizado) && !dataNormalizada) {
       filtros.push(
         where(cast(col('id'), 'TEXT'), {
           [Op.like]: `%${termoNormalizado}%`,
         }),
       );
-      filtros.push(...filtrosData);
     }
 
     const itens = await this.usuarioModel.findAll({
@@ -609,9 +556,18 @@ export class BuscaService {
     return somenteData.replace(/\//g, '-');
   }
 
-  private extrairFragmentoNumericoData(valor: string): string | undefined {
-    const numeros = valor.replace(/\D/g, '');
-    return numeros.length > 0 ? numeros : undefined;
+  private extrairIdExatoDoTermo(valor: string): number | undefined {
+    const somenteNumero = valor.match(/^\d+$/);
+    if (somenteNumero) {
+      return Number(somenteNumero[0]);
+    }
+
+    const formatoId = valor.match(/^id\s+(\d+)$/i);
+    if (formatoId) {
+      return Number(formatoId[1]);
+    }
+
+    return undefined;
   }
 
   private validarData(ano: number, mes: number, dia: number): boolean {
@@ -621,12 +577,5 @@ export class BuscaService {
       dataUtc.getUTCMonth() === mes - 1 &&
       dataUtc.getUTCDate() === dia
     );
-  }
-
-  private normalizarTextoBusca(valor: string): string {
-    return valor
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase();
   }
 }


### PR DESCRIPTION
# Mudanças - Sistema de Busca


## Resumo Executivo

Foram implementadas melhorias no sistema de busca em três módulos principais:
- **Serviços**: Busca parcial por valor base e prazo
- **Publicidade**: Busca tolerante a acentos
- **Usuários**: Busca por dígitos, incluindo data de cadastro

Todas as buscas agora funcionam **a cada dígito/caractere digitado** pelo usuário, sem necessidade de clicar em botão de busca.

---

## 1. SERVIÇOS - Busca Parcial por Valor e Prazo

### Problema Anterior
- Buscas por valor e prazo utilizavam comparação exata (`=`)
- Se o usuário digitasse `18`, não retornava valores como `180` ou `1880`
- Só funcionava com valor exato

### Solução Implementada
- Alterado de comparação exata para **busca parcial com LIKE**
- Campo `valor_base` agora usa: `CAST(valor_base AS TEXT) LIKE '%18%'`
- Campo `prazo_estimado_dias` agora usa: `CAST(prazo_estimado_dias AS TEXT) LIKE '%18%'`

### Exemplos de Funcionamento

| Campo | Digitado | Resultados |
|-------|----------|-----------|
| Valor | `18` | 18, 180, 1800, 1850, 218, 1180 |
| Valor | `100` | 100, 1000, 1001, 10000 |
| Prazo | `5` | 5, 15, 25, 50, 51, 52 |
| Prazo | `30` | 30, 130, 230, 300 |

### Arquivos Modificados
- `back-end/src/modules/busca/busca.service.ts`
  - Método: `buscarServicosPorFiltros()` (linhas 61-85)
  - Método: `listarServicosByTermo()` (linhas 478-516)

---

## 2. PUBLICIDADE - Busca Tolerante a Acentos

### Problema Anterior
- Buscas por "cafe" não encontravam "café"
- Buscas por "sao paulo" não encontravam "São Paulo"
- Usuário precisava digitar exatamente com acentos

### Solução Implementada
- Implementada função `normalizarTextoBusca()` que:
  - Remove acentos usando `normalize('NFD')`
  - Converte para minúsculas
  - Realiza comparação sem acentuação

**Fórmula de normalização:**
```javascript
valor
  .normalize('NFD')                    // Separa acento da letra
  .replace(/[\u0300-\u036f]/g, '')   // Remove diacríticos
  .toLowerCase()                       // Converte para minúscula
```

### Exemplos de Funcionamento

| Digitado | Encontra |
|----------|----------|
| `cafe` | café, Café, CAFÉ |
| `sao` | São, São Paulo, são |
| `acao` | ação, Ação, AÇÃO |
| `coracaozinho` | coraçãozinho, Coraçãozinho |

### Arquivos Modificados

**Back-End:**
- `back-end/src/modules/busca/busca.service.ts`
  - Método: `listarPublicidadeByTermo()` (linhas 354-416)
  - Método: `normalizarTextoBusca()` (linhas 566-572)

### Fluxo de Busca
1. Tenta busca direta no banco de dados (com LIKE padrão)
2. Se não encontra, busca no JavaScript/Node com normalização de acentos
3. Retorna resultados combinados

---

## 3. USUÁRIOS - Busca por Dígitos e Data

### Problema Anterior
- Busca por data exigia formato completo: `dd/mm/aaaa` ou `aaaa-mm-dd`
- Digite `03/03` não retornava nada
- Dígitos como `11` retornavam resultados de celular/CPF, não de data
- Sem busca automática a cada dígito

### Solução Implementada

#### 3.1 Busca por Data Parcial
- Aceita qualquer fragmento: `03`, `11`, `03/03`, `03-03`
- Converte data em banco para TEXT e faz comparação parcial
- Função `extrairFragmentoNumericoData()` extrai números puros

#### 3.2 Priorização de Resultados
- Se entrada é só números/separadores, busca **primeiro** por data
- Se encontra resultados por data, retorna esses
- Só busca em outros campos (celular, CPF) se não encontrar por data

#### 3.3 Busca Automática a Cada Dígito
- Debounce de 350ms
- Dispara requisição ao backend a cada mudança

### Exemplos de Funcionamento

| Campo | Digitado | Retorna |
|-------|----------|---------|
| Busca | `03` | Todos com data contendo 03 (dia, mês) |
| Busca | `11` | Todos com data contendo 11 (dia, mês) |
| Busca | `03/03` | Todos com 03-03 na data |
| Busca | `03/03/2026` | Usuários cadastrados em 03/03/2026 |
| Busca | `João` | Usuários com nome "João" |
| Busca | `email@` | Usuários com email contendo "email@" |

### Arquivos Modificados

**Back-End:**
- `back-end/src/modules/busca/busca.service.ts`
  - Método: `listarUsuariosByTermo()` (linhas 418-511)
  - Método: `extrairFragmentoNumericoData()` (linhas 580-583)
  - Método: `normalizarDataBuscaParcial()` (linhas 574-583)
  - Adicionada priorização por data (linhas 484-502)

---