### PR TITLE
262 feature implementação de criação de usuários painel de admin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ async function bootstrap() {
     .setTitle('Laboratório de Práticas')
     .setDescription('Documentação da API')
     .setVersion('1.0')
+    .addBearerAuth()
     .build();
   const documentFactory = () => SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('swagger', app, documentFactory);

--- a/src/modules/usuario/dto/create-admin.dto.ts
+++ b/src/modules/usuario/dto/create-admin.dto.ts
@@ -1,0 +1,62 @@
+import {
+  IsString,
+  IsEmail,
+  IsEnum,
+  IsOptional,
+  MinLength,
+  MaxLength,
+  IsNotEmpty,
+  Matches,
+} from 'class-validator';
+import { Expose, Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { NivelUsuario } from './create-usuario.dto';
+
+export class CreateAdminUsuarioDto {
+  @ApiProperty({ example: 'João Silva' })
+  @IsString()
+  @MaxLength(100)
+  @IsNotEmpty()
+  nome!: string;
+
+  @ApiProperty({ example: 'joao@empresa.com' })
+  @IsEmail()
+  @MaxLength(100)
+  @IsNotEmpty()
+  email!: string;
+
+  @ApiProperty({ example: 'senhaTemporaria123', minLength: 6 })
+  @IsString()
+  @MinLength(6, { message: 'A senha deve ter no mínimo 6 caracteres' })
+  @MaxLength(255)
+  @IsNotEmpty()
+  senha!: string;
+
+  @ApiProperty({ enum: NivelUsuario, example: NivelUsuario.cliente })
+  @IsNotEmpty()
+  @IsEnum(NivelUsuario, { message: 'Nível inválido' })
+  nivel!: NivelUsuario;
+
+  @ApiPropertyOptional({ example: '00000000000' })
+  @IsOptional()
+  @Expose({ name: 'cpf_cnpj' })
+  @Transform(
+    ({
+      obj,
+      value,
+    }: {
+      obj: { cpfCnpj?: string; cpf_cnpj?: string };
+      value?: string;
+    }) => obj.cpf_cnpj ?? obj.cpfCnpj ?? value,
+    { toClassOnly: true },
+  )
+  @IsString()
+  @Matches(/^(\d{11}|\d{14})$/, { message: 'CPF/CNPJ inválido' })
+  cpfCnpj?: string;
+
+  @ApiPropertyOptional({ example: '13999999999' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{10,11}$/, { message: 'Celular inválido' })
+  celular?: string;
+}

--- a/src/modules/usuario/guards/admin.guard.ts
+++ b/src/modules/usuario/guards/admin.guard.ts
@@ -3,34 +3,41 @@ import {
   CanActivate,
   ExecutionContext,
   ForbiddenException,
+  UnauthorizedException,
 } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
 
 type NivelUsuario = 'cliente' | 'administrador';
 
-interface UsuarioAutenticado {
+interface JwtPayload {
   id: number;
   nivel: NivelUsuario;
 }
 
-interface RequestComUsuario {
-  user?: UsuarioAutenticado;
-  headers: {
-    'x-user-id'?: string;
-    'x-user-nivel'?: string;
-  };
-}
-
 @Injectable()
 export class AdminGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
   canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest<RequestComUsuario>();
+    const request = context.switchToHttp().getRequest<Request>();
 
-    const user = request.user ?? {
-      id: Number(request.headers['x-user-id']),
-      nivel: request.headers['x-user-nivel'] as NivelUsuario,
-    };
+    const authHeader = request.headers['authorization'];
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Token não fornecido');
+    }
 
-    if (!user || user.nivel !== 'administrador') {
+    const token = authHeader.split(' ')[1];
+
+    try {
+      const payload = this.jwtService.verify<JwtPayload>(token);
+      (request as Request & { user: JwtPayload }).user = payload;
+    } catch {
+      throw new UnauthorizedException('Token inválido ou expirado');
+    }
+
+    const user = (request as Request & { user: JwtPayload }).user;
+    if (user.nivel !== 'administrador') {
       throw new ForbiddenException('Acesso negado');
     }
 

--- a/src/modules/usuario/usuario.controller.spec.ts
+++ b/src/modules/usuario/usuario.controller.spec.ts
@@ -8,9 +8,12 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { UsuarioOwnerGuard } from './guards/usuario-owner.guard';
+import { NivelUsuario } from './dto/create-usuario.dto';
+import { AdminGuard } from './guards/admin.guard';
 
 const mockUsuarioService = {
   create: jest.fn(),
+  createByAdmin: jest.fn(),
   login: jest.fn(),
   remove: jest.fn(),
   update: jest.fn(),
@@ -34,6 +37,8 @@ describe('UsuarioController', () => {
       ],
     })
       .overrideGuard(UsuarioOwnerGuard)
+      .useValue(mockGuard)
+      .overrideGuard(AdminGuard)
       .useValue(mockGuard)
       .compile();
 
@@ -115,6 +120,62 @@ describe('UsuarioController', () => {
       const result = await controller.register(dtoCompleto);
 
       expect(result).toEqual(respostaCompleta);
+    });
+  });
+
+  describe('createByAdmin', () => {
+    const dtoAdmin = {
+      nome: 'João Silva',
+      email: 'joao@empresa.com',
+      senha: 'senhaTemporaria123',
+      nivel: NivelUsuario.administrador,
+    };
+
+    const respostaMock = {
+      id: 45,
+      nome: 'João Silva',
+      email: 'joao@empresa.com',
+      nivel: 'administrador',
+      cpf_cnpj: null,
+      celular: null,
+      data_cadastro: new Date(),
+    };
+
+    it('deve chamar o service com o dto correto e retornar o usuário criado', async () => {
+      mockUsuarioService.createByAdmin.mockResolvedValue(respostaMock);
+
+      const result = await controller.createByAdmin(dtoAdmin);
+
+      expect(mockUsuarioService.createByAdmin).toHaveBeenCalledWith(dtoAdmin);
+      expect(result).toEqual(respostaMock);
+    });
+
+    it('não deve retornar o campo senha na resposta', async () => {
+      mockUsuarioService.createByAdmin.mockResolvedValue(respostaMock);
+
+      const result = await controller.createByAdmin(dtoAdmin);
+
+      expect(result).not.toHaveProperty('senha');
+    });
+
+    it('deve propagar ConflictException quando e-mail já estiver cadastrado', async () => {
+      mockUsuarioService.createByAdmin.mockRejectedValue(
+        new ConflictException('Esse e-mail já está cadastrado no sistema.'),
+      );
+
+      await expect(controller.createByAdmin(dtoAdmin)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('deve propagar ConflictException quando CPF/CNPJ já estiver cadastrado', async () => {
+      mockUsuarioService.createByAdmin.mockRejectedValue(
+        new ConflictException('Esse CPF/CNPJ já está cadastrado no sistema.'),
+      );
+
+      await expect(
+        controller.createByAdmin({ ...dtoAdmin, cpfCnpj: '00000000000' }),
+      ).rejects.toThrow(ConflictException);
     });
   });
 

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -16,6 +16,7 @@ import { AdminGuard } from './guards/admin.guard';
 import { CreateUsuarioDto } from './dto/create-usuario.dto';
 import {
   ApiBadRequestResponse,
+  ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
   ApiOkResponse,
@@ -46,6 +47,7 @@ export class UsuarioController {
 
   @Post('/admin/usuarios')
   @UseGuards(AdminGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: 'Cria um usuário via painel administrativo' })
   @ApiCreatedResponse({
     description: 'Usuário criado com sucesso',

--- a/src/modules/usuario/usuario.controller.ts
+++ b/src/modules/usuario/usuario.controller.ts
@@ -24,6 +24,7 @@ import {
 } from '@nestjs/swagger';
 import { ResponseUsuarioDto } from './dto/response-usuario.dto';
 import { LoginUsuarioDto } from './dto/login-usuario.dto';
+import { CreateAdminUsuarioDto } from './dto/create-admin.dto';
 
 @Controller('usuario')
 export class UsuarioController {
@@ -41,6 +42,21 @@ export class UsuarioController {
   @ApiConflictResponse({ description: 'E-mail já cadastrado no sistema' })
   register(@Body() createUsuarioDto: CreateUsuarioDto) {
     return this.usuarioService.create(createUsuarioDto);
+  }
+
+  @Post('/admin/usuarios')
+  @UseGuards(AdminGuard)
+  @ApiOperation({ summary: 'Cria um usuário via painel administrativo' })
+  @ApiCreatedResponse({
+    description: 'Usuário criado com sucesso',
+    type: ResponseUsuarioDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Token inválido ou sem permissão de administrador',
+  })
+  @ApiConflictResponse({ description: 'E-mail ou CPF/CNPJ já cadastrado' })
+  createByAdmin(@Body() createAdminUsuarioDto: CreateAdminUsuarioDto) {
+    return this.usuarioService.createByAdmin(createAdminUsuarioDto);
   }
 
   @Post('login')

--- a/src/modules/usuario/usuario.service.spec.ts
+++ b/src/modules/usuario/usuario.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
+import { NivelUsuario } from './dto/create-usuario.dto';
 
 jest.mock('bcrypt', () => ({
   hash: jest.fn().mockResolvedValue('hashed_password'),
@@ -132,7 +133,71 @@ describe('UsuarioService', () => {
     });
   });
 
-   describe('login', () => {
+  describe('createByAdmin', () => {
+    const dtoAdmin = {
+      nome: 'João Silva',
+      email: 'joao@empresa.com',
+      senha: 'senhaTemporaria123',
+      nivel: NivelUsuario.administrador,
+    };
+
+    const mockAdminUsuario = {
+      ...mockUsuario,
+      nivel: 'administrador',
+      toJSON: jest.fn().mockReturnValue({
+        ...mockUsuarioToJSON,
+        nivel: 'administrador',
+      }),
+    };
+
+    it('deve criar usuário com o nível definido pelo admin', async () => {
+      mockUsuarioModel.findOne.mockResolvedValue(null);
+      mockUsuarioModel.create.mockResolvedValue(mockAdminUsuario);
+
+      const result = await service.createByAdmin(dtoAdmin);
+
+      expect(mockUsuarioModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nome: dtoAdmin.nome,
+          email: dtoAdmin.email,
+          senha: 'hashed_password',
+          nivel: 'administrador',
+        }),
+      );
+      expect(result).not.toHaveProperty('senha');
+    });
+
+    it('deve lançar ConflictException se e-mail já estiver cadastrado', async () => {
+      mockUsuarioModel.findOne.mockResolvedValue(mockUsuario);
+
+      await expect(service.createByAdmin(dtoAdmin)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(mockUsuarioModel.create).not.toHaveBeenCalled();
+    });
+
+    it('deve lançar ConflictException se CPF/CNPJ já estiver cadastrado', async () => {
+      mockUsuarioModel.findOne
+        .mockResolvedValueOnce(null)       // email livre
+        .mockResolvedValueOnce(mockUsuario); // cpf duplicado
+
+      await expect(
+        service.createByAdmin({ ...dtoAdmin, cpfCnpj: '00000000000' }),
+      ).rejects.toThrow(ConflictException);
+      expect(mockUsuarioModel.create).not.toHaveBeenCalled();
+    });
+
+    it('deve lançar InternalServerErrorException se o create falhar', async () => {
+      mockUsuarioModel.findOne.mockResolvedValue(null);
+      mockUsuarioModel.create.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.createByAdmin(dtoAdmin)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('login', () => {
     const dtoLogin = {
       email: 'davi@example.com',
       senha: 'senha123',
@@ -298,39 +363,39 @@ describe('UsuarioService', () => {
       ).resolves.not.toThrow();
     });
   });
-  
-describe('findOne', () => {
-  it('deve retornar um usuário por id sem senha', async () => {
-    mockUsuarioModel.findByPk.mockResolvedValue(mockUsuario);
 
-    const result = await service.findOne(1);
+  describe('findOne', () => {
+    it('deve retornar um usuário por id sem senha', async () => {
+      mockUsuarioModel.findByPk.mockResolvedValue(mockUsuario);
 
-    expect(mockUsuarioModel.findByPk).toHaveBeenCalledWith(1, {
-      attributes: { exclude: ['senha'] },
+      const result = await service.findOne(1);
+
+      expect(mockUsuarioModel.findByPk).toHaveBeenCalledWith(1, {
+        attributes: { exclude: ['senha'] },
+      });
+
+      expect(result).toMatchObject({
+        id: mockUsuario.id,
+        nome: mockUsuario.nome,
+        email: mockUsuario.email,
+        nivel: mockUsuario.nivel,
+        cpf_cnpj: mockUsuario.cpfCnpj ?? null,
+        celular: mockUsuario.celular,
+        data_cadastro: mockUsuario.dataCadastro,
+      });
+
+      expect(result).not.toHaveProperty('senha');
     });
 
-    expect(result).toMatchObject({
-      id: mockUsuario.id,
-      nome: mockUsuario.nome,
-      email: mockUsuario.email,
-      nivel: mockUsuario.nivel,
-      cpf_cnpj: mockUsuario.cpfCnpj ?? null,
-      celular: mockUsuario.celular,
-      data_cadastro: mockUsuario.dataCadastro,
+    it('deve lançar NotFoundException se usuário não existir', async () => {
+      mockUsuarioModel.findByPk.mockResolvedValue(null);
+
+      await expect(service.findOne(999)).rejects.toThrow(
+        NotFoundException,
+      );
     });
-
-    expect(result).not.toHaveProperty('senha');
   });
 
-  it('deve lançar NotFoundException se usuário não existir', async () => {
-    mockUsuarioModel.findByPk.mockResolvedValue(null);
-
-    await expect(service.findOne(999)).rejects.toThrow(
-      NotFoundException,
-    );
-  });
-});
-  
   describe('findAll', () => {
     it('deve retornar lista de usuários sem senha', async () => {
       const usuariosMock = [

--- a/src/modules/usuario/usuario.service.ts
+++ b/src/modules/usuario/usuario.service.ts
@@ -14,6 +14,7 @@ import { ResponseUsuarioDto } from './dto/response-usuario.dto';
 import { plainToInstance } from 'class-transformer';
 import { LoginUsuarioDto } from './dto/login-usuario.dto';
 import { JwtService } from '@nestjs/jwt';
+import { CreateAdminUsuarioDto } from './dto/create-admin.dto';
 
 @Injectable()
 export class UsuarioService {
@@ -40,6 +41,47 @@ export class UsuarioService {
         email: dto.email,
         senha: senhaHash,
         nivel: 'cliente',
+        cpfCnpj: dto.cpfCnpj ?? null,
+        celular: dto.celular ?? null,
+      });
+
+      return plainToInstance(ResponseUsuarioDto, usuario.toJSON(), {
+        excludeExtraneousValues: true,
+      });
+    } catch {
+      throw new InternalServerErrorException('Erro ao criar usuário');
+    }
+  }
+
+  async createByAdmin(dto: CreateAdminUsuarioDto): Promise<ResponseUsuarioDto> {
+    const emailExistente = await this.usuarioModel.findOne({
+      where: { email: dto.email },
+    });
+
+    if (emailExistente) {
+      throw new ConflictException('Esse e-mail já está cadastrado no sistema.');
+    }
+
+    if (dto.cpfCnpj) {
+      const cpfExistente = await this.usuarioModel.findOne({
+        where: { cpfCnpj: dto.cpfCnpj },
+      });
+
+      if (cpfExistente) {
+        throw new ConflictException(
+          'Esse CPF/CNPJ já está cadastrado no sistema.',
+        );
+      }
+    }
+
+    const senhaHash = await bcrypt.hash(dto.senha, 10);
+
+    try {
+      const usuario = await this.usuarioModel.create({
+        nome: dto.nome,
+        email: dto.email,
+        senha: senhaHash,
+        nivel: dto.nivel,
         cpfCnpj: dto.cpfCnpj ?? null,
         celular: dto.celular ?? null,
       });


### PR DESCRIPTION
Como solicitado, foi implementada a rota que permite ao administrador criar novos usuários, garantindo que possuam e-mails e CPFs únicos, além de permitir a definição do nível de acesso, podendo ser cliente ou administrador. Também foi corrigida a autenticação via token JWT para garantir o funcionamento correto da rota e assegurar que apenas administradores tenham acesso a ela. 
 closes #262 