### PR TITLE
Chore/atualiza infra para suportar pupeeter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,58 @@
-FROM node:22-alpine AS deps
+FROM node:22-slim AS deps
+
 WORKDIR /app
+
 COPY package*.json ./
+
+# Evita download automático do Chrome pelo Puppeteer
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+
 RUN npm ci
 
-FROM node:22-alpine AS builder
+FROM node:22-slim AS builder
+
 WORKDIR /app
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
 RUN npm run build && npm prune --omit=dev
 
-FROM node:22-alpine AS runner
+FROM node:22-slim AS runner
+
 WORKDIR /app
+
 ENV NODE_ENV=production
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Instala Chromium e dependências necessárias
+RUN apt-get update && apt-get install -y \
+    chromium \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxrandr2 \
+    xdg-utils \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 
 EXPOSE 8080
+
 CMD ["node", "dist/main.js"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,19 +17,23 @@ steps:
           SAFE_BRANCH=$(printf '%s' "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
           docker push "southamerica-east1-docker.pkg.dev/$PROJECT_ID/backend-repo/backend-$${SAFE_BRANCH}:$COMMIT_SHA"
 
-  # Deploy no Cloud Run (serviço nomeado pela branch)
+  # Deploy no Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: sh
     args:
       - -c
       - |
           SAFE_BRANCH=$(printf '%s' "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+
           gcloud run deploy "backend-$${SAFE_BRANCH}" \
             --image="southamerica-east1-docker.pkg.dev/$PROJECT_ID/backend-repo/backend-$${SAFE_BRANCH}:$COMMIT_SHA" \
             --region="southamerica-east1" \
             --platform="managed" \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --port=8080 \
+            --memory=1Gi \
+            --cpu=1 \
+            --timeout=300
 
-# Solução Service Account:
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/src/modules/reports/pdf-generator.service.ts
+++ b/src/modules/reports/pdf-generator.service.ts
@@ -958,7 +958,13 @@ export class PdfGeneratorService {
 
       browser = await puppeteer.launch({
         headless: true,
-        args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
+        executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+        ],
       });
 
       const page = await browser.newPage();


### PR DESCRIPTION

Este pull request atualiza a configuração do Docker e o deploy para oferecer melhor suporte ao Puppeteer com Chromium em um ambiente Node.js, além de garantir compatibilidade com implantações no Cloud Run. As principais mudanças incluem a substituição das imagens Alpine por imagens Slim do Node.js, a instalação do Chromium e suas dependências, a configuração do Puppeteer para usar o Chromium instalado no sistema e o refinamento dos parâmetros de deploy no Cloud Run.

## Melhorias no Docker e no Puppeteer

- As imagens base no `Dockerfile` foram alteradas de `node:22-alpine` para `node:22-slim`, com a instalação do Chromium e de todas as dependências necessárias do sistema, garantindo que o Puppeteer utilize o navegador instalado localmente em vez de tentar realizar um download automático. A variável de ambiente `PUPPETEER_EXECUTABLE_PATH` foi configurada para garantir a resolução correta do caminho do Chromium.

- As opções de inicialização do Puppeteer em `pdf-generator.service.ts` foram atualizadas para usar a variável de ambiente `PUPPETEER_EXECUTABLE_PATH`, além da adição da flag `--disable-dev-shm-usage` para melhorar a estabilidade em ambientes containerizados.

## Melhorias no deploy do Cloud Run

- A etapa de deploy do Cloud Run em `cloudbuild.yaml` foi modificada para definir explicitamente os parâmetros de porta, memória, CPU e timeout, garantindo que o serviço implantado corresponda aos requisitos da aplicação e escute na porta correta.
