### PR TITLE
feat: adiciona rotas diretas para status da solicitacao

### DIFF
--- a/src/modules/solicitacao/solicitacao.controller.spec.ts
+++ b/src/modules/solicitacao/solicitacao.controller.spec.ts
@@ -9,6 +9,8 @@ describe('SolicitacaoController', () => {
   const mockSolicitacaoService = {
     criarSolicitacao: jest.fn(),
     updateSolicitacaoStatusById: jest.fn(),
+    cancelarSolicitacao: jest.fn(),
+    reabrirSolicitacao: jest.fn(),
     listarSolicitacoes: jest.fn(),
     enviarDocumento: jest.fn(),
   };
@@ -87,5 +89,25 @@ describe('SolicitacaoController', () => {
     expect(
       mockSolicitacaoService.updateSolicitacaoStatusById,
     ).toHaveBeenCalledWith(1, updateDto);
+  });
+
+  it('deve cancelar solicitacao com sucesso', async () => {
+    const resposta = { id: 123, status: 'cancelado' };
+    mockSolicitacaoService.cancelarSolicitacao.mockResolvedValue(resposta);
+
+    await expect(controller.cancelarSolicitacao(123)).resolves.toEqual(
+      resposta,
+    );
+    expect(mockSolicitacaoService.cancelarSolicitacao).toHaveBeenCalledWith(
+      123,
+    );
+  });
+
+  it('deve reabrir solicitacao com sucesso', async () => {
+    const resposta = { id: 123, status: 'em_andamento' };
+    mockSolicitacaoService.reabrirSolicitacao.mockResolvedValue(resposta);
+
+    await expect(controller.reabrirSolicitacao(123)).resolves.toEqual(resposta);
+    expect(mockSolicitacaoService.reabrirSolicitacao).toHaveBeenCalledWith(123);
   });
 });

--- a/src/modules/solicitacao/solicitacao.controller.ts
+++ b/src/modules/solicitacao/solicitacao.controller.ts
@@ -148,9 +148,9 @@ export class SolicitacaoController {
 
   @Post(':id/cancelar')
   @ApiOperation({
-    summary: 'Cancelar solicitaÃ§Ã£o',
+    summary: 'Cancelar solicitação',
     description:
-      'Cancela uma solicitaÃ§Ã£o utilizando a funÃ§Ã£o central de atualizaÃ§Ã£o de status.',
+      'Cancela uma solicitação utilizando a função central de atualização de status.',
   })
   @ApiOkResponse({
     description: 'Cancelamento realizado com sucesso',
@@ -163,7 +163,7 @@ export class SolicitacaoController {
     },
   })
   @ApiNotFoundResponse({
-    description: 'SolicitaÃ§Ã£o nÃ£o encontrada',
+    description: 'Solicitação não encontrada',
   })
   @HttpCode(HttpStatus.OK)
   cancelarSolicitacao(
@@ -174,9 +174,9 @@ export class SolicitacaoController {
 
   @Post(':id/reabrir')
   @ApiOperation({
-    summary: 'Reabrir solicitaÃ§Ã£o',
+    summary: 'Reabrir solicitação',
     description:
-      'Reabre uma solicitaÃ§Ã£o cancelada utilizando a funÃ§Ã£o central de atualizaÃ§Ã£o de status.',
+      'Reabre uma solicitação cancelada utilizando a função central de atualização de status.',
   })
   @ApiOkResponse({
     description: 'Reabertura realizada com sucesso',
@@ -189,7 +189,7 @@ export class SolicitacaoController {
     },
   })
   @ApiNotFoundResponse({
-    description: 'SolicitaÃ§Ã£o nÃ£o encontrada',
+    description: 'Solicitação não encontrada',
   })
   @HttpCode(HttpStatus.OK)
   reabrirSolicitacao(

--- a/src/modules/solicitacao/solicitacao.controller.ts
+++ b/src/modules/solicitacao/solicitacao.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Logger,
   Param,
   ParseIntPipe,
@@ -163,6 +165,7 @@ export class SolicitacaoController {
   @ApiNotFoundResponse({
     description: 'SolicitaÃ§Ã£o nÃ£o encontrada',
   })
+  @HttpCode(HttpStatus.OK)
   cancelarSolicitacao(
     @Param('id', ParseIntPipe) id: number,
   ): Promise<{ id: number; status: 'cancelado' }> {
@@ -188,6 +191,7 @@ export class SolicitacaoController {
   @ApiNotFoundResponse({
     description: 'SolicitaÃ§Ã£o nÃ£o encontrada',
   })
+  @HttpCode(HttpStatus.OK)
   reabrirSolicitacao(
     @Param('id', ParseIntPipe) id: number,
   ): Promise<{ id: number; status: 'em_andamento' }> {

--- a/src/modules/solicitacao/solicitacao.controller.ts
+++ b/src/modules/solicitacao/solicitacao.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -7,7 +6,6 @@ import {
   Param,
   ParseIntPipe,
   Post,
-  Put,
   UploadedFile,
   UseInterceptors,
 } from '@nestjs/common';
@@ -19,7 +17,6 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
-  ApiProperty,
   ApiTags,
 } from '@nestjs/swagger';
 import { DocumentoFilePipe } from 'src/commons/pipes/file.pipe';
@@ -145,6 +142,56 @@ export class SolicitacaoController {
       id,
       updateSolicitacaoStatusDto,
     );
+  }
+
+  @Post(':id/cancelar')
+  @ApiOperation({
+    summary: 'Cancelar solicitaÃ§Ã£o',
+    description:
+      'Cancela uma solicitaÃ§Ã£o utilizando a funÃ§Ã£o central de atualizaÃ§Ã£o de status.',
+  })
+  @ApiOkResponse({
+    description: 'Cancelamento realizado com sucesso',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 123 },
+        status: { type: 'string', example: 'cancelado' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'SolicitaÃ§Ã£o nÃ£o encontrada',
+  })
+  cancelarSolicitacao(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<{ id: number; status: 'cancelado' }> {
+    return this.solicitacaoService.cancelarSolicitacao(id);
+  }
+
+  @Post(':id/reabrir')
+  @ApiOperation({
+    summary: 'Reabrir solicitaÃ§Ã£o',
+    description:
+      'Reabre uma solicitaÃ§Ã£o cancelada utilizando a funÃ§Ã£o central de atualizaÃ§Ã£o de status.',
+  })
+  @ApiOkResponse({
+    description: 'Reabertura realizada com sucesso',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 123 },
+        status: { type: 'string', example: 'em_andamento' },
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'SolicitaÃ§Ã£o nÃ£o encontrada',
+  })
+  reabrirSolicitacao(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<{ id: number; status: 'em_andamento' }> {
+    return this.solicitacaoService.reabrirSolicitacao(id);
   }
 
   @Post(':id/documentos')

--- a/src/modules/solicitacao/solicitacao.service.spec.ts
+++ b/src/modules/solicitacao/solicitacao.service.spec.ts
@@ -726,6 +726,26 @@ describe('SolicitacaoService', () => {
         }),
       );
     });
+
+    it('deve falhar quando o envio do email de status falhar', async () => {
+      const solicitacao = mockSolicitacaoComRelacoes('em_andamento', 10);
+      mockSolicitacaoModel.findByPk.mockResolvedValue(solicitacao);
+      mockEmailService.enviarEmail.mockRejectedValue(
+        new Error('Falha no envio de email'),
+      );
+
+      await expect(
+        service.updateSolicitacaoStatusById(10, {
+          status: StatusSolicitacaoEnum.CANCELADO,
+        }),
+      ).rejects.toThrow('Falha no envio de email');
+
+      expect(solicitacao.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: StatusSolicitacaoEnum.CANCELADO,
+        }),
+      );
+    });
   });
 
   describe('rotas diretas de status', () => {

--- a/src/modules/solicitacao/solicitacao.service.spec.ts
+++ b/src/modules/solicitacao/solicitacao.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/sequelize';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CloudinaryService } from 'src/infra/cloudinary/cloudinary.service';
@@ -723,6 +724,92 @@ describe('SolicitacaoService', () => {
           status: 'em_andamento',
           observacaoAdmin: 'Verificado pelo admin',
         }),
+      );
+    });
+  });
+
+  describe('rotas diretas de status', () => {
+    it('deve cancelar solicitacao usando a atualizacao central', async () => {
+      const solicitacao = {
+        id: 10,
+        status: StatusSolicitacaoEnum.EM_ANDAMENTO,
+        usuario: { id: 1, nome: 'Amanda', email: 'amanda@email.com' },
+        servico: { id: 3, nome: 'Transferencia' },
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockSolicitacaoModel.findByPk.mockResolvedValue(solicitacao);
+
+      await expect(service.cancelarSolicitacao(10)).resolves.toEqual({
+        id: 10,
+        status: StatusSolicitacaoEnum.CANCELADO,
+      });
+
+      expect(solicitacao.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: StatusSolicitacaoEnum.CANCELADO,
+        }),
+      );
+      expect(mockEmailService.enviarEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'amanda@email.com',
+          template: 'status-update',
+        }),
+      );
+    });
+
+    it('deve retornar conflito ao cancelar solicitacao concluida', async () => {
+      mockSolicitacaoModel.findByPk.mockResolvedValue({
+        id: 11,
+        status: StatusSolicitacaoEnum.CONCLUIDO,
+        usuario: { id: 1, nome: 'Amanda', email: 'amanda@email.com' },
+        servico: { id: 3, nome: 'Transferencia' },
+      });
+
+      await expect(service.cancelarSolicitacao(11)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+    });
+
+    it('deve reabrir solicitacao cancelada usando a atualizacao central', async () => {
+      const solicitacao = {
+        id: 12,
+        status: StatusSolicitacaoEnum.CANCELADO,
+        usuario: { id: 1, nome: 'Amanda', email: 'amanda@email.com' },
+        servico: { id: 3, nome: 'Transferencia' },
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      mockSolicitacaoModel.findByPk.mockResolvedValue(solicitacao);
+
+      await expect(service.reabrirSolicitacao(12)).resolves.toEqual({
+        id: 12,
+        status: StatusSolicitacaoEnum.EM_ANDAMENTO,
+      });
+
+      expect(solicitacao.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: StatusSolicitacaoEnum.EM_ANDAMENTO,
+        }),
+      );
+      expect(mockEmailService.enviarEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'amanda@email.com',
+          template: 'status-update',
+        }),
+      );
+    });
+
+    it('deve retornar conflito ao reabrir solicitacao nao cancelada', async () => {
+      mockSolicitacaoModel.findByPk.mockResolvedValue({
+        id: 13,
+        status: StatusSolicitacaoEnum.RECEBIDO,
+        usuario: { id: 1, nome: 'Amanda', email: 'amanda@email.com' },
+        servico: { id: 3, nome: 'Transferencia' },
+      });
+
+      await expect(service.reabrirSolicitacao(13)).rejects.toBeInstanceOf(
+        ConflictException,
       );
     });
   });

--- a/src/modules/solicitacao/solicitacao.service.ts
+++ b/src/modules/solicitacao/solicitacao.service.ts
@@ -287,20 +287,14 @@ export class SolicitacaoService implements OnModuleDestroy {
         const textos = obterTextosEmailPorStatus(novoStatus, isReabertura);
 
         if (textos) {
-          void this.dispararEmailStatus(
+          await this.dispararEmailStatus(
             solicitacao,
             textos.assunto,
             textos.titulo,
             textos.mensagem,
             textos.cor,
             observacao,
-          ).catch((error: unknown) => {
-            const mensagemErro =
-              error instanceof Error ? error.message : 'Erro desconhecido';
-            this.logger.warn(
-              `Falha ao enviar email de status para solicitacao ${id}: ${mensagemErro}`,
-            );
-          });
+          );
         }
       }
     }

--- a/src/modules/solicitacao/solicitacao.service.ts
+++ b/src/modules/solicitacao/solicitacao.service.ts
@@ -1,7 +1,6 @@
 import {
   BadRequestException,
-  HttpException,
-  HttpStatus,
+  ConflictException,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -308,6 +307,51 @@ export class SolicitacaoService implements OnModuleDestroy {
 
     return {
       message: 'Status da solicitação atualizado com sucesso.',
+    };
+  }
+
+  async cancelarSolicitacao(
+    id: number,
+  ): Promise<{ id: number; status: StatusSolicitacaoEnum.CANCELADO }> {
+    const solicitacao = await this.findSolicitacaoById(id);
+    const statusAtual = solicitacao.status as StatusSolicitacaoEnum;
+
+    if (
+      statusAtual === StatusSolicitacaoEnum.CANCELADO ||
+      statusAtual === StatusSolicitacaoEnum.CONCLUIDO
+    ) {
+      throw new ConflictException(
+        'SolicitaÃ§Ã£o jÃ¡ estÃ¡ cancelada ou nÃ£o pode ser cancelada',
+      );
+    }
+
+    await this.updateSolicitacaoStatusById(id, {
+      status: StatusSolicitacaoEnum.CANCELADO,
+    });
+
+    return {
+      id,
+      status: StatusSolicitacaoEnum.CANCELADO,
+    };
+  }
+
+  async reabrirSolicitacao(
+    id: number,
+  ): Promise<{ id: number; status: StatusSolicitacaoEnum.EM_ANDAMENTO }> {
+    const solicitacao = await this.findSolicitacaoById(id);
+    const statusAtual = solicitacao.status as StatusSolicitacaoEnum;
+
+    if (statusAtual !== StatusSolicitacaoEnum.CANCELADO) {
+      throw new ConflictException('SolicitaÃ§Ã£o nÃ£o estÃ¡ cancelada');
+    }
+
+    await this.updateSolicitacaoStatusById(id, {
+      status: StatusSolicitacaoEnum.EM_ANDAMENTO,
+    });
+
+    return {
+      id,
+      status: StatusSolicitacaoEnum.EM_ANDAMENTO,
     };
   }
 

--- a/src/modules/solicitacao/solicitacao.service.ts
+++ b/src/modules/solicitacao/solicitacao.service.ts
@@ -315,7 +315,7 @@ export class SolicitacaoService implements OnModuleDestroy {
       statusAtual === StatusSolicitacaoEnum.CONCLUIDO
     ) {
       throw new ConflictException(
-        'SolicitaÃ§Ã£o jÃ¡ estÃ¡ cancelada ou nÃ£o pode ser cancelada',
+        'Solicitação já está cancelada ou não pode ser cancelada',
       );
     }
 
@@ -336,7 +336,7 @@ export class SolicitacaoService implements OnModuleDestroy {
     const statusAtual = solicitacao.status as StatusSolicitacaoEnum;
 
     if (statusAtual !== StatusSolicitacaoEnum.CANCELADO) {
-      throw new ConflictException('SolicitaÃ§Ã£o nÃ£o estÃ¡ cancelada');
+      throw new ConflictException('Solicitação não está cancelada');
     }
 
     await this.updateSolicitacaoStatusById(id, {


### PR DESCRIPTION
## Descrição
Implementa as rotas `POST /solicitacoes/:id/cancelar` e `POST /solicitacoes/:id/reabrir` no módulo de agendamento, reutilizando o fluxo central de atualização de status e garantindo o envio de notificação somente após a alteração bem-sucedida.

## Alterações
- Adição das rotas de cancelamento e reabertura
- Implementação das validações de regra de negócio
- Inclusão de testes para cenários de sucesso e conflito

closes #267 
