### PR TITLE
feat: Inclusão da rota de substituição de arquivo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -185,8 +185,10 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -208,8 +210,10 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -277,8 +281,10 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -300,8 +306,10 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -1007,9 +1015,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1025,9 +1030,6 @@
       "integrity": "sha512-wHQykZw3pX2R5Yp5VChOWzVXXO3XPdgWkQH1B9QBmft926EOkZpwxvubeAYy9I89qJzzdGNqiRl26+AUP88J3A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1045,9 +1047,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,9 +1062,6 @@
       "integrity": "sha512-DO/cba/zndTY3s86nNNfeHx7DvrvLb+IxhkQWTr29IQeiUgbawCH9X3B/4Li2eo/sEx/imOOnYDdXYu8PeX2Fg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1456,9 +1452,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1474,9 +1467,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1494,9 +1484,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1512,9 +1499,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1532,9 +1516,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1550,9 +1531,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1570,9 +1548,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1589,9 +1564,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1607,9 +1579,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1633,9 +1602,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1657,9 +1623,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1683,9 +1646,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1707,9 +1667,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1733,9 +1690,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1758,9 +1712,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1782,9 +1733,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3533,8 +3481,10 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -3556,8 +3506,10 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -3717,6 +3669,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4670,9 +4623,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4687,9 +4637,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4704,9 +4651,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4721,9 +4665,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4738,9 +4679,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4755,9 +4693,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4772,9 +4707,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4789,9 +4721,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14400,6 +14329,7 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {

--- a/src/commons/pipes/file.pipe.ts
+++ b/src/commons/pipes/file.pipe.ts
@@ -39,7 +39,11 @@ export class DocumentoFilePipe implements PipeTransform {
       throw new BadRequestException('Arquivo excede o tamanho máximo de 10MB');
     }
 
-    if (!DOCUMENTO_MIME_TYPES.includes(file.mimetype as any)) {
+    if (
+      !DOCUMENTO_MIME_TYPES.includes(
+        file.mimetype as (typeof DOCUMENTO_MIME_TYPES)[number],
+      )
+    ) {
       throw new BadRequestException(
         `Tipo de arquivo inválido. Tipos permitidos: ${DOCUMENTO_MIME_TYPES.join(', ')}`,
       );

--- a/src/commons/utils/crypto.ts
+++ b/src/commons/utils/crypto.ts
@@ -22,6 +22,17 @@ export class CryptoUtil {
   decrypt(encryptedText: string): string {
     const [ivHex, encrypted] = encryptedText.split(':');
 
+    if (
+      !ivHex ||
+      !encrypted ||
+      ivHex.length !== 32 ||
+      !/^[0-9a-f]+$/i.test(ivHex)
+    ) {
+      throw new Error(
+        `Formato de texto criptografado inválido (iv.length=${ivHex?.length ?? 0}, hasPayload=${!!encrypted})`,
+      );
+    }
+
     const iv = Buffer.from(ivHex, 'hex');
 
     const decipher = crypto.createDecipheriv(this.algorithm, this.key, iv);

--- a/src/infra/cloudinary/cloudinary.service.ts
+++ b/src/infra/cloudinary/cloudinary.service.ts
@@ -131,6 +131,47 @@ export class CloudinaryService {
     });
   }
 
+  async deleteDocument(decryptedHash: string): Promise<void> {
+    try {
+      const separador = decryptedHash.indexOf('|');
+      if (separador === -1) {
+        this.logger.warn(
+          `deleteDocument: formato inválido de hash (separador '|' não encontrado) — asset não removido`,
+        );
+        return;
+      }
+
+      const resourceType = decryptedHash.slice(0, separador) as 'raw' | 'image';
+      const publicId = decryptedHash.slice(separador + 1);
+
+      interface CloudinaryDestroyResult {
+        result?: string;
+      }
+
+      const resultado = (await this.cloudinary.uploader.destroy(publicId, {
+        resource_type: resourceType,
+        type: 'authenticated',
+        invalidate: true,
+      })) as CloudinaryDestroyResult;
+
+      if (resultado.result === 'ok') {
+        this.logger.log(
+          `Asset removido do Cloudinary: ${publicId} (type=${resourceType})`,
+        );
+      } else {
+        this.logger.warn(
+          `Cloudinary não confirmou remoção do asset ${publicId}: result=${resultado.result ?? 'desconhecido'}`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `Falha ao remover asset do Cloudinary: ${
+          error instanceof Error ? error.message : 'Erro desconhecido'
+        }`,
+      );
+    }
+  }
+
   generateTemporaryUrl(publicIdWithResourceType: string): string {
     try {
       const separador = publicIdWithResourceType.indexOf('|');

--- a/src/infra/email/dto/email-params.ts
+++ b/src/infra/email/dto/email-params.ts
@@ -3,13 +3,13 @@ export class EmailParams {
   template: string;
   assunto: string;
   withHeader?: boolean;
-  dados: Record<string, object>;
+  dados: Record<string, unknown>;
 
   constructor(
     to: string,
     template: string,
     assunto: string,
-    dados: Record<string, any>,
+    dados: Record<string, unknown>,
     withHeader?: boolean,
   ) {
     this.to = to;

--- a/src/modules/solicitacao/solicitacao.controller.spec.ts
+++ b/src/modules/solicitacao/solicitacao.controller.spec.ts
@@ -11,6 +11,7 @@ describe('SolicitacaoController', () => {
     updateSolicitacaoStatusById: jest.fn(),
     listarSolicitacoes: jest.fn(),
     enviarDocumento: jest.fn(),
+    substituirDocumento: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -87,5 +88,31 @@ describe('SolicitacaoController', () => {
     expect(
       mockSolicitacaoService.updateSolicitacaoStatusById,
     ).toHaveBeenCalledWith(1, updateDto);
+  });
+
+  it('deve substituir documento via PATCH com sucesso', async () => {
+    const mockArquivo = {
+      originalname: 'documento.pdf',
+      mimetype: 'application/pdf',
+      buffer: Buffer.from('fake-content'),
+      size: 1024,
+    } as Express.Multer.File;
+
+    const resposta = {
+      id: 10,
+      mensagem: 'Documento substituído com sucesso',
+    };
+
+    mockSolicitacaoService.substituirDocumento.mockResolvedValue(resposta);
+
+    await expect(
+      controller.substituirDocumento(1, 10, mockArquivo),
+    ).resolves.toEqual(resposta);
+
+    expect(mockSolicitacaoService.substituirDocumento).toHaveBeenCalledWith(
+      1,
+      10,
+      mockArquivo,
+    );
   });
 });

--- a/src/modules/solicitacao/solicitacao.controller.ts
+++ b/src/modules/solicitacao/solicitacao.controller.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Body,
   Controller,
   Get,
@@ -7,7 +6,6 @@ import {
   Param,
   ParseIntPipe,
   Post,
-  Put,
   UploadedFile,
   UseInterceptors,
 } from '@nestjs/common';
@@ -19,10 +17,9 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
-  ApiProperty,
   ApiTags,
 } from '@nestjs/swagger';
-import { DocumentoFilePipe } from 'src/commons/pipes/file.pipe';
+import { DocumentoFilePipe } from '../../commons/pipes/file.pipe';
 import { CreateDocumentoDto } from './dto/create-documento.dto';
 import { CreateSolicitacaoResponseDto } from './dto/create-solicitacao-response.dto';
 import { CreateSolicitacaoDto } from './dto/create-solicitacao.dto';
@@ -196,5 +193,53 @@ export class SolicitacaoController {
     documento: Express.Multer.File,
   ): Promise<{ message: string }> {
     return this.solicitacaoService.enviarDocumento(id, data, documento);
+  }
+
+  @Patch(':id/documentos/:docId')
+  @ApiOperation({
+    summary: 'Substituir arquivo de um documento vinculado a uma solicitação',
+    description:
+      'Substitui o arquivo de um documento já vinculado a uma solicitação, mantendo o mesmo vínculo e identificação do documento.',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiOkResponse({
+    description: 'Documento substituído com sucesso',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'number', example: 1 },
+        mensagem: {
+          type: 'string',
+          example: 'Documento substituído com sucesso',
+        },
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'Solicitação ou documento não encontrado',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        documento: { type: 'string', format: 'binary' },
+      },
+      required: ['documento'],
+    },
+  })
+  @UseInterceptors(
+    FileInterceptor('documento', {
+      limits: {
+        fileSize: 10 * 1024 * 1024,
+      },
+    }),
+  )
+  substituirDocumento(
+    @Param('id', ParseIntPipe) id: number,
+    @Param('docId', ParseIntPipe) docId: number,
+    @UploadedFile(DocumentoFilePipe)
+    documento: Express.Multer.File,
+  ): Promise<{ id: number; mensagem: string }> {
+    return this.solicitacaoService.substituirDocumento(id, docId, documento);
   }
 }

--- a/src/modules/solicitacao/solicitacao.controller.ts
+++ b/src/modules/solicitacao/solicitacao.controller.ts
@@ -14,6 +14,7 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
+  ApiBadRequestResponse,
   ApiConsumes,
   ApiCreatedResponse,
   ApiNotFoundResponse,
@@ -21,7 +22,7 @@ import {
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { DocumentoFilePipe } from '../../commons/pipes/file.pipe';
+import { DocumentoFilePipe } from 'src/commons/pipes/file.pipe';
 import { CreateDocumentoDto } from './dto/create-documento.dto';
 import { CreateSolicitacaoResponseDto } from './dto/create-solicitacao-response.dto';
 import { CreateSolicitacaoDto } from './dto/create-solicitacao.dto';
@@ -271,6 +272,24 @@ export class SolicitacaoController {
   })
   @ApiNotFoundResponse({
     description: 'Solicitação ou documento não encontrado',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Requisição inválida. Possíveis causas: (1) arquivo ausente ou em formato/tamanho inválido; (2) o documento informado não pertence à solicitação.',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        error: { type: 'string', example: 'Bad Request' },
+        message: {
+          type: 'string',
+          examples: [
+            'Arquivo obrigatório não enviado ou formato inválido',
+            'Documento não pertence à solicitação informada',
+          ],
+        },
+      },
+    },
   })
   @ApiBody({
     schema: {

--- a/src/modules/solicitacao/solicitacao.service.spec.ts
+++ b/src/modules/solicitacao/solicitacao.service.spec.ts
@@ -26,6 +26,11 @@ interface MockEmailService {
   enviarEmail: jest.Mock;
 }
 
+interface MockCloudinaryService {
+  uploadDocument: jest.Mock;
+  generateTemporaryUrl: jest.Mock;
+}
+
 describe('SolicitacaoService', () => {
   let service: SolicitacaoService;
 
@@ -45,6 +50,7 @@ describe('SolicitacaoService', () => {
   let mockServicoModel: MockModel;
   let mockNotificacaoService: MockNotificacao;
   let mockEmailService: MockEmailService;
+  let mockCloudinaryService: MockCloudinaryService;
 
   beforeEach(async () => {
     mockSolicitacaoModel = {
@@ -119,7 +125,7 @@ describe('SolicitacaoService', () => {
             generateTemporaryUrl: jest.fn(
               (publicId) => `https://temp-url/${publicId}`,
             ),
-          },
+          } satisfies MockCloudinaryService,
         },
         {
           provide: CryptoUtil,
@@ -138,6 +144,9 @@ describe('SolicitacaoService', () => {
     }).compile();
 
     service = module.get<SolicitacaoService>(SolicitacaoService);
+    mockCloudinaryService = module.get<CloudinaryService>(
+      CloudinaryService,
+    ) as unknown as MockCloudinaryService;
   });
 
   afterEach(() => {
@@ -724,6 +733,93 @@ describe('SolicitacaoService', () => {
           observacaoAdmin: 'Verificado pelo admin',
         }),
       );
+    });
+  });
+
+  describe('substituirDocumento', () => {
+    const mockArquivo = {
+      originalname: 'documento.pdf',
+      mimetype: 'application/pdf',
+      buffer: Buffer.from('fake-file-content'),
+      size: 1024,
+    } as Express.Multer.File;
+
+    it('deve substituir documento com sucesso', async () => {
+      mockSolicitacaoModel.findByPk.mockResolvedValue({ id: 1 });
+
+      const mockDocumento = {
+        id: 10,
+        solicitacaoId: 1,
+        nomeHash: 'old-hash',
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+      mockDocumentoModel.findByPk.mockResolvedValue(mockDocumento);
+
+      mockCloudinaryService.uploadDocument.mockResolvedValue({
+        public_id: 'docs/new-doc-id',
+        resource_type: 'raw',
+      });
+
+      const result = await service.substituirDocumento(1, 10, mockArquivo);
+
+      expect(result).toEqual({
+        id: 10,
+        mensagem: 'Documento substituído com sucesso',
+      });
+      expect(mockDocumento.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nomeHash: expect.any(String) as string,
+          dataUpload: expect.any(Date) as Date,
+        }),
+      );
+      expect(mockCloudinaryService.uploadDocument).toHaveBeenCalledWith(
+        mockArquivo,
+      );
+    });
+
+    it('deve retornar 404 quando solicitacao nao encontrada', async () => {
+      mockSolicitacaoModel.findByPk.mockResolvedValue(null);
+
+      await expect(
+        service.substituirDocumento(999, 10, mockArquivo),
+      ).rejects.toThrow('Solicitação não encontrada');
+    });
+
+    it('deve retornar 404 quando documento nao encontrado', async () => {
+      mockSolicitacaoModel.findByPk.mockResolvedValue({ id: 1 });
+      mockDocumentoModel.findByPk.mockResolvedValue(null);
+
+      await expect(
+        service.substituirDocumento(1, 999, mockArquivo),
+      ).rejects.toThrow('Documento não encontrado');
+    });
+
+    it('deve retornar 400 quando documento nao pertence a solicitacao', async () => {
+      mockSolicitacaoModel.findByPk.mockResolvedValue({ id: 1 });
+      mockDocumentoModel.findByPk.mockResolvedValue({
+        id: 10,
+        solicitacaoId: 2,
+      });
+
+      await expect(
+        service.substituirDocumento(1, 10, mockArquivo),
+      ).rejects.toThrow('Documento não pertence à solicitação informada');
+    });
+
+    it('deve retornar erro quando upload no cloudinary falhar', async () => {
+      mockSolicitacaoModel.findByPk.mockResolvedValue({ id: 1 });
+      mockDocumentoModel.findByPk.mockResolvedValue({
+        id: 10,
+        solicitacaoId: 1,
+      });
+
+      mockCloudinaryService.uploadDocument.mockRejectedValue(
+        new Error('Cloudinary error'),
+      );
+
+      await expect(
+        service.substituirDocumento(1, 10, mockArquivo),
+      ).rejects.toThrow('Erro ao enviar documento: Cloudinary error');
     });
   });
 });

--- a/src/modules/solicitacao/solicitacao.service.ts
+++ b/src/modules/solicitacao/solicitacao.service.ts
@@ -5,6 +5,7 @@ import {
   InternalServerErrorException,
   Logger,
   NotFoundException,
+  OnModuleDestroy,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { StatusSolicitacaoEnum } from 'src/commons/enums/status-solicitacao.enum';

--- a/src/modules/solicitacao/solicitacao.service.ts
+++ b/src/modules/solicitacao/solicitacao.service.ts
@@ -1,7 +1,5 @@
 import {
   BadRequestException,
-  HttpException,
-  HttpStatus,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -513,6 +511,64 @@ export class SolicitacaoService implements OnModuleDestroy {
     });
     return {
       message: 'Documento enviado com sucesso e aguardando validação.',
+    };
+  }
+
+  async substituirDocumento(
+    solicitacaoId: number,
+    docId: number,
+    arquivo: Express.Multer.File,
+  ): Promise<{ id: number; mensagem: string }> {
+    const solicitacao = await this.solicitacaoModel.findByPk(solicitacaoId);
+    if (!solicitacao) {
+      throw new NotFoundException('Solicitação não encontrada');
+    }
+
+    const documento = await this.documentoModel.findByPk(docId);
+    if (!documento) {
+      throw new NotFoundException('Documento não encontrado');
+    }
+
+    if (documento.solicitacaoId !== solicitacaoId) {
+      throw new BadRequestException(
+        'Documento não pertence à solicitação informada',
+      );
+    }
+
+    let urlDocRestricted: CloudinaryResponse;
+
+    try {
+      urlDocRestricted = await this.cloudinaryService.uploadDocument(arquivo);
+    } catch (error) {
+      const mensagemErro =
+        error instanceof Error ? error.message : 'Erro desconhecido';
+
+      this.logger.error(
+        `Falha ao enviar documento substituto para a solicitacao ${solicitacaoId}: ${mensagemErro}`,
+      );
+
+      throw new BadRequestException(
+        `Erro ao enviar documento: ${mensagemErro}`,
+      );
+    }
+
+    const publicId = urlDocRestricted.public_id as string;
+    if (!publicId) {
+      throw new InternalServerErrorException(
+        'Resposta inválida do Cloudinary: public_id ausente',
+      );
+    }
+    const resourceType = urlDocRestricted.resource_type as 'raw' | 'image';
+    const nomeHash = this.cryptoUtil.encrypt(`${resourceType}|${publicId}`);
+
+    await documento.update({
+      nomeHash: nomeHash,
+      dataUpload: new Date(),
+    });
+
+    return {
+      id: documento.id,
+      mensagem: 'Documento substituído com sucesso',
     };
   }
 }

--- a/src/modules/solicitacao/solicitacao.service.ts
+++ b/src/modules/solicitacao/solicitacao.service.ts
@@ -575,6 +575,21 @@ export class SolicitacaoService implements OnModuleDestroy {
       );
     }
 
+    if (documento.nomeHash) {
+      void (async () => {
+        try {
+          const decryptedHash = this.cryptoUtil.decrypt(documento.nomeHash!);
+          await this.cloudinaryService.deleteDocument(decryptedHash);
+        } catch (err) {
+          this.logger.error(
+            `Falha ao remover asset antigo do Cloudinary para doc ${docId}: ${
+              err instanceof Error ? err.message : 'Erro desconhecido'
+            }`,
+          );
+        }
+      })();
+    }
+
     let urlDocRestricted: CloudinaryResponse;
 
     try {
@@ -604,6 +619,7 @@ export class SolicitacaoService implements OnModuleDestroy {
     await documento.update({
       nomeHash: nomeHash,
       dataUpload: new Date(),
+      statusValidacao: 'pendente',
     });
 
     return {


### PR DESCRIPTION
Realizada a implementação da rota de substituição de documento em uma solicitação já existente.

**Alterações realizadas**

**1- Método substituirDocumento**

Adicionado o método substituirDocumento(solicitacaoId, docId, arquivo). O fluxo funciona da seguinte maneira:

- Busca a solicitação por ID → 404 se não encontrada
- Busca o documento por ID → 404 se não encontrado
- Valida se documento.solicitacaoId === solicitacaoId → 400 se não pertence
- Faz upload do novo arquivo no Cloudinary via cloudinaryService.uploadDocument()
- Criptografa o public_id com cryptoUtil.encrypt()
- Atualiza o nomeHash e dataUpload do documento existente
- Retorna { id: docId, mensagem: "Documento substituído com sucesso" }

Adicionei também nos spec em solicitação para testar a respeito

**2- Endpoint @Patch(':id/documentos/:docId')**

Faz uma analise do documento enviado para verificar se está válido e no tamanho de 10MB

closes #281 