### PR TITLE
FEATURE: Implementar validação de JWT e autorização por roles (ADMIN/CLIENTE)

### DIFF
--- a/src/modules/usuario/decorators/roles.decorator.ts
+++ b/src/modules/usuario/decorators/roles.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+import { NivelUsuario } from '../guards/jwt-auth.guard';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: NivelUsuario[]) =>
+  SetMetadata(ROLES_KEY, roles);

--- a/src/modules/usuario/guards/jwt-auth.guard.ts
+++ b/src/modules/usuario/guards/jwt-auth.guard.ts
@@ -1,0 +1,39 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Request } from 'express';
+
+export type NivelUsuario = 'cliente' | 'administrador';
+
+export interface JwtPayload {
+  id: number;
+  nivel: NivelUsuario;
+}
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    const authHeader = request.headers['authorization'];
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Token não fornecido');
+    }
+
+    const token = authHeader.split(' ')[1];
+
+    try {
+      const payload = this.jwtService.verify<JwtPayload>(token);
+      (request as Request & { user: JwtPayload }).user = payload;
+      return true;
+    } catch {
+      throw new UnauthorizedException('Token inválido ou expirado');
+    }
+  }
+}

--- a/src/modules/usuario/guards/roles.guard.ts
+++ b/src/modules/usuario/guards/roles.guard.ts
@@ -1,0 +1,39 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { JwtPayload, NivelUsuario } from './jwt-auth.guard';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const rolesPermitidas = this.reflector.getAllAndOverride<NivelUsuario[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!rolesPermitidas || rolesPermitidas.length === 0) return true;
+
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & { user: JwtPayload }>();
+
+    if (!request.user) {
+      throw new UnauthorizedException('Usuário não autenticado');
+    }
+
+    if (!rolesPermitidas.includes(request.user.nivel)) {
+      throw new ForbiddenException('Acesso negado');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Foi realizada a implementação da validação de JWT nas requisições e controle de autorização por perfil de usuário. Foram criados o jwt-auth.guard, responsável por validar o token enviado no header Authorization e injetar os dados do usuário em req.user, e o roles.guard, responsável por verificar se o usuário possui a role necessária para acessar a rota, retornando 401 para token inválido/ausente e 403 para acesso não autorizado.

closes #300 